### PR TITLE
Add mustache-style template delimiters

### DIFF
--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -88,17 +88,17 @@ def gemini_prompt_template(rdg_file:str, use_filesystem_cache=True, **kwargs) ->
 
 def ollama_prompt(rdg_file:str, use_filesystem_cache=True, **kwargs) -> str:
   """Sends the file content to an LLM and returns the response using caching."""
-    
+
   try:
+      if "template" not in kwargs:
+          raise RdgParserError("Template must be supplied when using the GEMINIPROMPT")
+      template = kwargs.pop("template")
+
       input_data = {}
       for key, value in kwargs.items():
           # Pass file_dir to process input
           input_data[key] = process_input(value, os.path.dirname(rdg_file))
-          
-      if "template" in kwargs:
-          template = kwargs.pop("template")
-      else:
-          raise RdgParserError("Template must be supplied when using the GEMINIPROMPT")
+
       rendered_template = render_template(template, input_data)
 
       logging.info(f"Rendered template:\n{rendered_template}")
@@ -110,17 +110,17 @@ def ollama_prompt(rdg_file:str, use_filesystem_cache=True, **kwargs) -> str:
 
 def gemini_prompt(rdg_file:str, use_filesystem_cache=True, **kwargs) -> str:
     """Sends the file content to an LLM and returns the response using caching."""
-    
+
     try:
+        if "template" not in kwargs:
+            raise RdgParserError("Template must be supplied when using the GEMINIPROMPT")
+        template = kwargs.pop("template")
+
         input_data = {}
         for key, value in kwargs.items():
             # Pass file_dir to process input
             input_data[key] = process_input(value, os.path.dirname(rdg_file))
-            
-        if "template" in kwargs:
-            template = kwargs.pop("template")
-        else:
-            raise RdgParserError("Template must be supplied when using the GEMINIPROMPT")
+
         rendered_template = render_template(template, input_data)
 
         logging.info(f"Rendered template:\n{rendered_template}")
@@ -142,24 +142,25 @@ def gemini_prompt(rdg_file:str, use_filesystem_cache=True, **kwargs) -> str:
 
 def gemini_prompt_from_file(rdg_file:str, use_filesystem_cache=True, **kwargs) -> str:
     """Sends the file content to an LLM and returns the response using caching."""
-    
+
     try:
+        if "template_file" not in kwargs:
+            raise RdgParserError("Template file must be supplied when using the GEMINIPROMPTFILE")
+
+        template_file = kwargs.pop("template_file")
+        template_file = process_input(template_file, os.path.dirname(rdg_file))
+
+        if os.path.exists(template_file):
+            with open(template_file, 'r') as f:
+                template = f.read()
+        else:
+            template = template_file
+
         input_data = {}
         for key, value in kwargs.items():
             # Pass file_dir to process input
             input_data[key] = process_input(value, os.path.dirname(rdg_file))
-            
-        if "template_file" in kwargs:
-            template_file = kwargs.pop("template_file")
-            template_file = process_input(template_file, os.path.dirname(rdg_file))
-            
-            if os.path.exists(template_file):
-                with open(template_file, 'r') as f:
-                    template = f.read()
-            else:
-                template = template_file
-        else:
-            raise RdgParserError("Template file must be supplied when using the GEMINIPROMPTFILE")
+
         rendered_template = render_template(template, input_data)
 
         logging.info(f"Rendered template:\n{rendered_template}")
@@ -531,14 +532,14 @@ def glob_to_markdown(rdg_file: str, **kwargs) -> str:
 def create_gemini_prompt(rdg_file:str, **kwargs) -> str:
     """Returns the prompt that would be sent to Gemini, for debugging."""
     try:
+        if "template" not in kwargs:
+            raise RdgParserError("Template must be supplied when using the CREATEGEMINIPROMPT")
+        template = kwargs.pop("template")
+
         input_data = {}
         for key, value in kwargs.items():
             input_data[key] = process_input(value, os.path.dirname(rdg_file))
-            
-        if "template" in kwargs:
-            template = kwargs.pop("template")
-        else:
-            raise RdgParserError("Template must be supplied when using the CREATEGEMINIPROMPT")
+
         rendered_template = render_template(template, input_data)
 
         logging.info(f"Rendered template for CREATEGEMINIPROMPT:\n{rendered_template}")

--- a/src/rdg/gemini.py
+++ b/src/rdg/gemini.py
@@ -20,7 +20,7 @@ if api_key:
         model = genai.GenerativeModel(
             # model_name="gemini-1.5-pro",
             # model_name="gemini-1.5-flash",
-            model_name="gemini-2.5-flash",
+            model_name="gemini-3-flash-preview",
             # model_name="gemini-2.5-pro",
             generation_config=generation_config,
         )

--- a/src/rdg/parser.py
+++ b/src/rdg/parser.py
@@ -77,10 +77,17 @@ def process_rdg_file(rdg_file: str, file_dir: str = ".") -> None:
                     with open(output_path, 'w') as outfile:
                         outfile.write(result)
                 except RdgParserError as e:
-                    
                     print(f"Error processing line '{line.strip()}': {e}", file=sys.stderr)
+                    # Write error to output file so downstream consumers can see it
+                    error_content = f"## ERROR\n\n{e}\n"
+                    with open(output_path, 'w') as outfile:
+                        outfile.write(error_content)
                 except Exception as e:
                     print(f"An unexpected error occurred processing line '{line.strip()}': {e}", file=sys.stderr)
+                    # Write error to output file so downstream consumers can see it
+                    error_content = f"## ERROR\n\n{e}\n"
+                    with open(output_path, 'w') as outfile:
+                        outfile.write(error_content)
     except FileNotFoundError:
         print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
     except Exception as e:

--- a/src/rdg/template.py
+++ b/src/rdg/template.py
@@ -1,14 +1,51 @@
+import re
 from string import Template
-from typing import Dict
+
+# Mustache-style pattern: matches {{variable_name}}
+_MUSTACHE_RE = re.compile(r'\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}')
 
 def render_template(template_str, input_data):
-  try:
-      template = Template(template_str)
-      rendered = template.substitute(input_data)
-      if not rendered.strip():
-          raise ValueError("Rendered template is empty or contains only whitespace.")
-      return rendered
-  except KeyError as e:
-      raise ValueError(f"Template placeholder not found: {e}")
-  except Exception as e:
-      raise RuntimeError(f"Template rendering failed: {e}")
+    """Render template by replacing placeholders with input_data values.
+
+    Supports two syntaxes:
+    - {{variable}} (mustache-style, preferred — no collision with $ in financial content)
+    - $variable (legacy Python string.Template style, for backward compatibility)
+
+    If the template contains any {{...}} placeholders, mustache-style is used.
+    Otherwise, falls back to legacy $variable substitution.
+    """
+    if _MUSTACHE_RE.search(template_str):
+        return _render_mustache(template_str, input_data)
+    else:
+        return _render_legacy(template_str, input_data)
+
+def _render_mustache(template_str, input_data):
+    """Render using {{variable}} placeholders."""
+    def replacer(match):
+        key = match.group(1)
+        if key not in input_data:
+            raise ValueError(f"Template placeholder not found: '{key}'")
+        return input_data[key]
+
+    try:
+        rendered = _MUSTACHE_RE.sub(replacer, template_str)
+        if not rendered.strip():
+            raise ValueError("Rendered template is empty or contains only whitespace.")
+        return rendered
+    except ValueError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"Template rendering failed: {e}")
+
+def _render_legacy(template_str, input_data):
+    """Render using $variable placeholders (backward compatibility)."""
+    try:
+        template = Template(template_str)
+        rendered = template.substitute(input_data)
+        if not rendered.strip():
+            raise ValueError("Rendered template is empty or contains only whitespace.")
+        return rendered
+    except KeyError as e:
+        raise ValueError(f"Template placeholder not found: {e}")
+    except Exception as e:
+        raise RuntimeError(f"Template rendering failed: {e}")

--- a/test_template.py
+++ b/test_template.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Tests for the RDG template engine.
+
+Covers:
+- Mustache-style {{variable}} rendering
+- Legacy $variable backward compatibility
+- Automatic syntax detection
+- Dollar sign in financial content (the root cause this fix addresses)
+- Error handling for missing placeholders
+- Edge cases
+"""
+
+import sys
+import os
+import unittest
+import tempfile
+import shutil
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from rdg.template import render_template, _render_mustache, _render_legacy
+
+
+class TestMustacheRendering(unittest.TestCase):
+    """Tests for {{variable}} placeholder syntax."""
+
+    def test_single_placeholder(self):
+        result = render_template("Hello {{name}}", {"name": "World"})
+        self.assertEqual(result, "Hello World")
+
+    def test_multiple_placeholders(self):
+        result = render_template(
+            "{{greeting}} {{name}}, welcome to {{place}}",
+            {"greeting": "Hello", "name": "Alice", "place": "RtB"}
+        )
+        self.assertEqual(result, "Hello Alice, welcome to RtB")
+
+    def test_repeated_placeholder(self):
+        result = render_template(
+            "{{x}} + {{x}} = 2 * {{x}}",
+            {"x": "5"}
+        )
+        self.assertEqual(result, "5 + 5 = 2 * 5")
+
+    def test_underscore_in_variable_name(self):
+        result = render_template(
+            "{{code_primary}} and {{code_secondary}}",
+            {"code_primary": "Component A", "code_secondary": "Component B"}
+        )
+        self.assertEqual(result, "Component A and Component B")
+
+    def test_numeric_suffix_in_variable_name(self):
+        result = render_template(
+            "{{barrels_lifecycle}} {{barrels_strategy}}",
+            {"barrels_lifecycle": "exports1", "barrels_strategy": "exports2"}
+        )
+        self.assertEqual(result, "exports1 exports2")
+
+
+class TestFinancialContentWithMustache(unittest.TestCase):
+    """Tests proving dollar signs in financial content don't collide with mustache syntax.
+
+    This is the ROOT CAUSE this fix addresses: prompt templates discussing
+    financial values ($85K, ~$1.2M, viewModel$) crashed with string.Template.
+    """
+
+    def test_dollar_amounts_preserved(self):
+        """Dollar amounts like $85,077 must pass through unchanged."""
+        template = "The salary is $85,077/year. Analysis: {{analysis}}"
+        result = render_template(template, {"analysis": "looks good"})
+        self.assertEqual(result, "The salary is $85,077/year. Analysis: looks good")
+
+    def test_tilde_dollar_notation(self):
+        """~$1.2M notation used in probabilistic language must be preserved."""
+        template = "Median outcome: ~$1.2M advantage. Source: {{source}}"
+        result = render_template(template, {"source": "Monte Carlo"})
+        self.assertEqual(result, "Median outcome: ~$1.2M advantage. Source: Monte Carlo")
+
+    def test_rxjs_observable_suffix(self):
+        """viewModel$ (RxJS convention) must not be treated as a placeholder."""
+        template = "Bind via viewModel$ | async. Review: {{code}}"
+        result = render_template(template, {"code": "component.ts"})
+        self.assertEqual(result, "Bind via viewModel$ | async. Review: component.ts")
+
+    def test_mixed_dollar_content(self):
+        """Real-world behavior-alignment.md content that previously crashed."""
+        template = (
+            "Template line 47 says 'median outcome suggests ~$1.2M'. "
+            "The salary is $60,320/year. "
+            "Phase: {{phase}}"
+        )
+        result = render_template(template, {"phase": "Onboarding"})
+        self.assertIn("~$1.2M", result)
+        self.assertIn("$60,320", result)
+        self.assertIn("Onboarding", result)
+
+    def test_dollar_in_code_examples(self):
+        """Code examples with $variable syntax preserved in template content."""
+        template = (
+            'Check: `$code_primary` is placeholder syntax.\n'
+            'Use branded types: `const salary = nominalDollars(100000);`\n'
+            'Analysis: {{analysis}}'
+        )
+        result = render_template(template, {"analysis": "PASS"})
+        self.assertIn("$code_primary", result)
+        self.assertIn("PASS", result)
+
+    def test_multiple_financial_values(self):
+        """Template with many dollar values and few placeholders."""
+        template = (
+            "Compare:\n"
+            "- 4% rule: $40,000/yr\n"
+            "- RtB simulation: ~$52K/yr at P50\n"
+            "- Difference: ~$12K/yr\n"
+            "- 25x rule: $1,000,000\n"
+            "- RtB target: ~$1.3M at 85% confidence\n"
+            "\nVerdict: {{verdict}}"
+        )
+        result = render_template(template, {"verdict": "Simulation wins"})
+        self.assertIn("$40,000", result)
+        self.assertIn("~$52K", result)
+        self.assertIn("$1,000,000", result)
+        self.assertIn("~$1.3M", result)
+        self.assertIn("Simulation wins", result)
+
+
+class TestLegacyBackwardCompatibility(unittest.TestCase):
+    """Tests that $variable syntax still works when no {{...}} present."""
+
+    def test_simple_legacy_placeholder(self):
+        result = render_template("Hello $name", {"name": "World"})
+        self.assertEqual(result, "Hello World")
+
+    def test_multiple_legacy_placeholders(self):
+        result = render_template(
+            "$greeting $name, welcome to $place",
+            {"greeting": "Hello", "name": "Alice", "place": "RtB"}
+        )
+        self.assertEqual(result, "Hello Alice, welcome to RtB")
+
+    def test_legacy_with_braces(self):
+        """${variable} syntax also works in legacy mode."""
+        result = render_template("Hello ${name}!", {"name": "World"})
+        self.assertEqual(result, "Hello World!")
+
+
+class TestSyntaxAutoDetection(unittest.TestCase):
+    """Tests that the engine correctly chooses mustache vs legacy mode."""
+
+    def test_mustache_detected_when_present(self):
+        """If ANY {{...}} exists, mustache mode is used."""
+        result = render_template("{{greeting}} $literal_dollar", {"greeting": "Hi"})
+        # In mustache mode, $literal_dollar is plain text — NOT a placeholder
+        self.assertEqual(result, "Hi $literal_dollar")
+
+    def test_legacy_used_when_no_mustache(self):
+        """If no {{...}} exists, legacy mode is used."""
+        result = render_template("$greeting world", {"greeting": "Hi"})
+        self.assertEqual(result, "Hi world")
+
+    def test_mustache_mode_ignores_dollar_placeholders(self):
+        """Critical: in mustache mode, $variable is NOT substituted."""
+        result = render_template(
+            "Price: $100. Analysis: {{analysis}}",
+            {"analysis": "OK"}
+        )
+        self.assertEqual(result, "Price: $100. Analysis: OK")
+
+
+class TestErrorHandling(unittest.TestCase):
+    """Tests for error cases."""
+
+    def test_missing_mustache_placeholder_raises(self):
+        """Missing key in mustache mode raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            render_template("{{missing_key}}", {})
+        self.assertIn("missing_key", str(ctx.exception))
+
+    def test_missing_legacy_placeholder_raises(self):
+        """Missing key in legacy mode raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            render_template("$missing_key", {})
+        self.assertIn("missing_key", str(ctx.exception))
+
+    def test_empty_result_raises(self):
+        """Template that renders to whitespace-only raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            render_template("{{x}}", {"x": "   "})
+        self.assertIn("empty", str(ctx.exception).lower())
+
+    def test_partial_missing_key_mustache(self):
+        """One valid key, one missing — should raise for the missing one."""
+        with self.assertRaises(ValueError) as ctx:
+            render_template("{{a}} {{b}}", {"a": "present"})
+        self.assertIn("b", str(ctx.exception))
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Edge cases and boundary conditions."""
+
+    def test_adjacent_mustache_placeholders(self):
+        result = render_template("{{a}}{{b}}", {"a": "hello", "b": "world"})
+        self.assertEqual(result, "helloworld")
+
+    def test_placeholder_in_multiline_template(self):
+        template = "Line 1: {{a}}\nLine 2: {{b}}\nLine 3: no placeholder"
+        result = render_template(template, {"a": "A", "b": "B"})
+        self.assertEqual(result, "Line 1: A\nLine 2: B\nLine 3: no placeholder")
+
+    def test_empty_string_value(self):
+        """Empty string is a valid value (but template must not be all-whitespace after)."""
+        result = render_template("prefix{{x}}suffix", {"x": ""})
+        self.assertEqual(result, "prefixsuffix")
+
+    def test_multiline_value(self):
+        """Placeholder value can contain newlines."""
+        result = render_template("Code:\n{{code}}\nEnd", {"code": "line1\nline2\nline3"})
+        self.assertEqual(result, "Code:\nline1\nline2\nline3\nEnd")
+
+    def test_value_with_braces(self):
+        """Value containing {{ or }} should be inserted literally."""
+        result = render_template("Result: {{x}}", {"x": "{{not_a_var}}"})
+        # After substitution, the result contains {{not_a_var}} literally.
+        # The regex won't re-process it because sub() does a single pass.
+        self.assertEqual(result, "Result: {{not_a_var}}")
+
+    def test_large_value_substitution(self):
+        """Large values (file contents) substitute correctly."""
+        large_content = "x" * 100_000
+        result = render_template("File: {{content}}", {"content": large_content})
+        self.assertEqual(result, f"File: {large_content}")
+
+    def test_extra_keys_ignored(self):
+        """Extra keys in input_data that don't appear in template are silently ignored."""
+        result = render_template("{{a}}", {"a": "used", "b": "unused", "c": "also unused"})
+        self.assertEqual(result, "used")
+
+    def test_no_placeholders_at_all(self):
+        """Template with no placeholders of either kind — legacy path, no substitution."""
+        result = render_template("Just plain text with no placeholders", {})
+        self.assertEqual(result, "Just plain text with no placeholders")
+
+
+class TestKeyOrderingBehavior(unittest.TestCase):
+    """Tests that pop-before-build pattern works correctly.
+
+    The bug: functions like gemini_prompt_from_file() built input_data from
+    ALL kwargs before popping reserved keys (template, template_file). This
+    meant reserved keys leaked into input_data as placeholder values.
+
+    The fix: pop reserved keys FIRST, then build input_data from remaining kwargs.
+
+    We test the behavior through render_template directly since importing
+    functions.py requires the full package tree (llm.ollama etc.).
+    """
+
+    def test_reserved_key_not_in_input_data(self):
+        """Simulates the fixed behavior: template key is NOT in input_data.
+
+        Before fix: input_data = {"template_file": "/path/to/file", "code": "..."}
+        After fix:  input_data = {"code": "..."}
+        """
+        # Simulate the FIXED gemini_prompt_from_file behavior:
+        # 1. Pop template_file from kwargs
+        # 2. Build input_data from remaining kwargs only
+        kwargs = {"template_file": "prompts/test.md", "code": "fn main() {}"}
+        kwargs.pop("template_file")  # Step 1: pop reserved key
+        input_data = {k: v for k, v in kwargs.items()}  # Step 2: build from remainder
+
+        # template_file should NOT be in input_data
+        self.assertNotIn("template_file", input_data)
+        self.assertIn("code", input_data)
+
+        # Template using {{code}} should work
+        result = render_template("Review: {{code}}", input_data)
+        self.assertEqual(result, "Review: fn main() {}")
+
+    def test_reserved_key_in_template_raises(self):
+        """If template uses {{template_file}} and that key was correctly popped,
+        rendering should fail with a missing placeholder error."""
+        kwargs = {"template_file": "prompts/test.md", "code": "fn main() {}"}
+        kwargs.pop("template_file")
+        input_data = {k: v for k, v in kwargs.items()}
+
+        with self.assertRaises(ValueError) as ctx:
+            render_template("File: {{template_file}}", input_data)
+        self.assertIn("template_file", str(ctx.exception))
+
+    def test_buggy_behavior_would_leak_key(self):
+        """Demonstrates what the bug looked like: building input_data BEFORE popping.
+
+        This test documents the bug so we never regress.
+        """
+        kwargs = {"template_file": "prompts/test.md", "code": "fn main() {}"}
+        # BUG: build input_data from ALL kwargs (before popping)
+        buggy_input_data = {k: v for k, v in kwargs.items()}
+        # Then pop (too late — already copied into input_data)
+        kwargs.pop("template_file")
+
+        # template_file LEAKED into input_data — this is the bug
+        self.assertIn("template_file", buggy_input_data)
+
+        # With the buggy behavior, {{template_file}} would resolve (WRONG)
+        buggy_result = render_template("File: {{template_file}}", buggy_input_data)
+        self.assertEqual(buggy_result, "File: prompts/test.md")  # Bug: should have failed
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `{{variable}}` template syntax (mustache-style) as an alternative to `$variable`
- Backward compatible: if no `{{...}}` placeholders found, falls back to legacy `$variable` substitution
- Fixes `template_file`/`template` key ordering bug in `gemini_prompt_from_file()`, `gemini_prompt()`, `ollama_prompt()`, `create_gemini_prompt()` — reserved keys were included in `input_data` before being popped
- Writes errors to output files in `parser.py` so downstream consumers can see failures
- Updates Gemini model to `gemini-3-flash-preview`

## Motivation

RDG prompt templates for financial content contain literal `$` characters (`$85K`, `~$1.2M`, `viewModel$`) that collide with Python's `string.Template` `$variable` syntax, causing `Invalid placeholder in string` errors. Mustache-style `{{variable}}` eliminates this collision entirely — prompt authors write naturally without escaping.

## Test plan
- [ ] Existing `.rdg` files using `$variable` syntax continue to work unchanged (backward compat)
- [ ] New prompt templates using `{{variable}}` render correctly
- [ ] Templates with financial `$` content (`$85K`, `~$1.2M`) no longer crash
- [ ] `gemini_prompt_from_file()` no longer includes `template_file` as a placeholder value
- [ ] Parser errors are written to output files for downstream visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)