### PR TITLE
fix(parser): isolate per-line errors; exit non-zero on failure

### DIFF
--- a/src/rdg/parser.py
+++ b/src/rdg/parser.py
@@ -50,45 +50,71 @@ def parse_rdg_line(line: str, file_dir: str = ".") -> tuple[str, str, dict[str, 
     return output_file, formula_name, arguments
 
 
-def process_rdg_file(rdg_file: str, file_dir: str = ".") -> None:
-    """Processes the given rdg file."""
+def process_rdg_file(rdg_file: str, file_dir: str = ".") -> int:
+    """Process the given rdg file. Returns the number of steps that failed."""
+    failures = 0
     try:
         with open(rdg_file, 'r') as f:
             for line in f:
-                output_file, formula_name, arguments = parse_rdg_line(line, file_dir)
-                if not output_file:  # skip empty lines or comments
-                    continue
-
+                # Parsing happens INSIDE the per-line try. Outside it, a single malformed line or
+                # unknown formula raised past the loop to the file-level handler below, which
+                # silently abandoned every remaining line — and the CLI still reported success.
+                output_path = None
                 try:
-                    formula = FUNCTION_REGISTRY[formula_name]
-                    
-                    # Create the output directory if it doesn't exist
+                    output_file, formula_name, arguments = parse_rdg_line(line, file_dir)
+                    if not output_file:  # skip empty lines or comments
+                        continue
+
+                    # Resolved before the formula is looked up, so the error handlers always have a
+                    # path to write to. An unknown formula used to raise KeyError here, and the
+                    # handler then raised UnboundLocalError on output_path, aborting the file.
                     output_path = os.path.join(file_dir, output_file)
+                    formula = FUNCTION_REGISTRY[formula_name]
+
+                    # Create the output directory if it doesn't exist
                     output_dir = os.path.dirname(output_path)
                     if output_dir and not os.path.exists(output_dir):
                         os.makedirs(output_dir, exist_ok=True)
-                    
+
                     # Delete the output file if it exists
                     if os.path.exists(output_path):
                         os.remove(output_path)
-                    
+
                     result = formula(rdg_file, **arguments)
 
                     with open(output_path, 'w') as outfile:
                         outfile.write(result)
+                except KeyError as e:
+                    failures += 1
+                    print(f"Unknown formula on line '{line.strip()}': {e}", file=sys.stderr)
+                    _write_error(output_path, f"Unknown formula: {e}")
                 except RdgParserError as e:
+                    failures += 1
                     print(f"Error processing line '{line.strip()}': {e}", file=sys.stderr)
-                    # Write error to output file so downstream consumers can see it
-                    error_content = f"## ERROR\n\n{e}\n"
-                    with open(output_path, 'w') as outfile:
-                        outfile.write(error_content)
+                    _write_error(output_path, e)
                 except Exception as e:
+                    failures += 1
                     print(f"An unexpected error occurred processing line '{line.strip()}': {e}", file=sys.stderr)
-                    # Write error to output file so downstream consumers can see it
-                    error_content = f"## ERROR\n\n{e}\n"
-                    with open(output_path, 'w') as outfile:
-                        outfile.write(error_content)
+                    _write_error(output_path, e)
     except FileNotFoundError:
         print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
+        return 1
     except Exception as e:
         print(f"An unexpected error occurred: {e}", file=sys.stderr)
+        return 1
+    return failures
+
+
+def _write_error(output_path, error):
+    """Record the error in the step's own output so downstream consumers see it.
+
+    `output_path` is None when the line never parsed far enough to name a destination; there is
+    nowhere to write, and stderr already carries the reason.
+    """
+    if output_path is None:
+        return
+    try:
+        with open(output_path, 'w') as outfile:
+            outfile.write(f"## ERROR\n\n{error}\n")
+    except OSError as exc:
+        print(f"Could not write error to '{output_path}': {exc}", file=sys.stderr)

--- a/src/rdg/rdg_cli.py
+++ b/src/rdg/rdg_cli.py
@@ -8,5 +8,8 @@ if __name__ == "__main__":
     
     rdg_file = sys.argv[1]
     file_dir = os.path.dirname(os.path.abspath(rdg_file))  # get folder of rdg file
-    process_rdg_file(rdg_file, file_dir)
-    print("Rdg file parsed succesfully")
+    failures = process_rdg_file(rdg_file, file_dir)
+    if failures:
+        print(f"Rdg file processed with {failures} failed step(s)", file=sys.stderr)
+        sys.exit(1)
+    print("Rdg file processed successfully")

--- a/tests/test_parser_line_error_isolation.py
+++ b/tests/test_parser_line_error_isolation.py
@@ -1,0 +1,80 @@
+"""A bad line must not abandon the rest of the file, and must not report success.
+
+Before this fix, `parse_rdg_line` was called outside the per-line `try`, so one malformed line or
+unknown formula raised past the loop to the file-level handler. Every remaining step was silently
+skipped and the CLI still printed that the file had been parsed successfully, exiting 0.
+
+Hermetic: only deterministic formulas, no network, no model call.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class LineErrorIsolation(unittest.TestCase):
+    def _run(self, rdg_body, files):
+        """Write an .rdg plus its inputs into a temp dir and run the CLI over it."""
+        tmp = tempfile.mkdtemp()
+        for name, content in files.items():
+            path = os.path.join(tmp, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as handle:
+                handle.write(content)
+        rdg = os.path.join(tmp, "t.rdg")
+        with open(rdg, "w") as handle:
+            handle.write(rdg_body)
+        # Prepend rather than replace: an inherited PYTHONPATH may carry the venv's own entries.
+        inherited = os.environ.get("PYTHONPATH", "")
+        env = dict(os.environ, PYTHONPATH=REPO + (os.pathsep + inherited if inherited else ""))
+        proc = subprocess.run(
+            [sys.executable, "-m", "src.rdg.rdg_cli", rdg],
+            cwd=REPO, env=env, capture_output=True, text=True,
+        )
+        return tmp, proc
+
+    def test_a_malformed_line_does_not_abandon_later_steps(self):
+        # Line 2 is missing its closing paren. Line 3 is valid and must still run.
+        tmp, proc = self._run(
+            'out/a.md=FILESTOMARKDOWN(files="a.md")\n'
+            'out/b.md=FILESTOMARKDOWN(files="a.md"\n'
+            'out/c.md=FILESTOMARKDOWN(files="c.md")\n',
+            {"a.md": "alpha\n", "c.md": "gamma\n"},
+        )
+        self.assertTrue(os.path.exists(os.path.join(tmp, "out/a.md")), "step before the bad line")
+        self.assertTrue(
+            os.path.exists(os.path.join(tmp, "out/c.md")),
+            "step AFTER the bad line must still run; it was silently skipped before this fix",
+        )
+        with open(os.path.join(tmp, "out/c.md")) as handle:
+            self.assertIn("gamma", handle.read())
+        self.assertNotEqual(proc.returncode, 0, "a failed step must not exit 0")
+
+    def test_unknown_formula_does_not_abandon_later_steps(self):
+        # Formula names are case-sensitive; the second line names one that does not exist. Before
+        # the fix this raised KeyError, and the handler then raised UnboundLocalError on the
+        # not-yet-assigned output_path, taking the rest of the file with it.
+        tmp, proc = self._run(
+            'out/a.md=FILESTOMARKDOWN(files="a.md")\n'
+            'out/b.md=NoSuchFormula(files="a.md")\n'
+            'out/c.md=FILESTOMARKDOWN(files="c.md")\n',
+            {"a.md": "alpha\n", "c.md": "gamma\n"},
+        )
+        self.assertTrue(os.path.exists(os.path.join(tmp, "out/c.md")), "step after unknown formula")
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_a_clean_file_still_succeeds(self):
+        tmp, proc = self._run(
+            'out/a.md=FILESTOMARKDOWN(files="a.md")\n',
+            {"a.md": "alpha\n"},
+        )
+        self.assertTrue(os.path.exists(os.path.join(tmp, "out/a.md")))
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A single bad line abandoned the rest of the file and still reported success.

`parse_rdg_line` was called **outside** the per-line `try`, so one malformed line or one unknown
formula raised past the loop to the file-level handler. Every remaining step silently did not run,
and `rdg_cli` printed `Rdg file parsed succesfully` and exited **0**.

That last part is what makes it worth fixing: the failure is indistinguishable from success. Because
the engine deletes a step's destination before writing it, the skipped steps keep whatever bytes they
held from a previous run — so a consumer reads a stale file that looks current.

A second bug compounded it. `output_path` was assigned *after* the `FUNCTION_REGISTRY` lookup, but
the error handlers write to it. An unknown formula raised `KeyError` before the assignment, so the
handler itself raised `UnboundLocalError` — also taking the rest of the file down.

## Changes

- move parsing inside the per-line `try`, and initialise `output_path` per line
- resolve `output_path` **before** the registry lookup, so handlers always have a destination
- add an explicit `KeyError` branch for an unknown formula
- extract `_write_error`, which returns early when the line never parsed far enough to name a
  destination (nothing to write to; stderr already carries the reason)
- `process_rdg_file` returns the failed-step count; `rdg_cli` exits 1 when non-zero
- fix the `succesfully` spelling in the success message

## Measured

Same three-step file, line 2 missing a closing paren:

| | line 1 | line 2 | line 3 | returns | CLI |
|---|---|---|---|---|---|
| before | written | fails | **never runs** | `None` | exits **0** |
| after | written | fails, per-line | **written** | `1` | exits **1** |

## Test

`tests/test_parser_line_error_isolation.py` — hermetic: deterministic formulas only, no network, no
model call. Verified as a real control rather than assumed: **2 of its 3 cases fail against the
unpatched parser**, and all 3 pass with the fix. The third case (a clean file still succeeds and
exits 0) passes both ways, which is correct — clean files were never affected.

Full suite on this branch: **65 passed, 1 skipped** (62 before, plus these 3). No regressions.

## Base

Targets `feat/rdg-primary-claude` rather than `main` only because that is where the test suite lives;
`parser.py` and `rdg_cli.py` are byte-identical on both, so this retargets to `main` cleanly if you
prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
