### PR TITLE
feat(rdg): RDG_FORMULA_PATH — load formulas from outside the package

### DIFF
--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -669,3 +669,61 @@ FUNCTION_REGISTRY: Dict[str, Callable] = {
     "GLOBTOMARKDOWN": glob_to_markdown,
     "CREATEGEMINIPROMPT": create_gemini_prompt,
 }
+
+
+# ---------------------------------------------------------------------------
+# RDG_FORMULA_PATH — load formulas from outside this package
+# ---------------------------------------------------------------------------
+#
+# Lets a project add its own formulas without forking the engine. Set the env var to one or more
+# directories (os.pathsep separated); every module in them exporting a FORMULAS dict is merged into
+# FUNCTION_REGISTRY at import.
+#
+#     RDG_FORMULA_PATH=/path/to/my/formulas rdg my.rdg
+#
+# A formula module exports:
+#
+#     FORMULAS: Dict[str, Callable]      # name -> f(rdg_file: str, **kwargs) -> str
+#
+# matching what parser.py already calls — formula(rdg_file, **arguments) — whose return value is
+# written to the step's destination.
+#
+# Loading is FAIL-LOUD. A path that does not exist, a module that will not import, or a module
+# without a FORMULAS dict raises here rather than being skipped. A skipped module would leave its
+# formulas undefined, and the parser would later report them as an unknown formula — sending the
+# reader to their .rdg file to debug a typo that is not there.
+def _load_external_formulas():
+    import importlib.util
+    import os
+    import sys
+
+    raw = os.environ.get("RDG_FORMULA_PATH", "")
+    if not raw:
+        return
+    for directory in [d for d in raw.split(os.pathsep) if d]:
+        if not os.path.isdir(directory):
+            raise RuntimeError(
+                f"RDG_FORMULA_PATH names '{directory}', which is not a directory"
+            )
+        for entry in sorted(os.listdir(directory)):
+            if not entry.endswith(".py") or entry.startswith("_"):
+                continue
+            path = os.path.join(directory, entry)
+            mod_name = "rdg_external_" + entry[:-3].replace("-", "_")
+            spec = importlib.util.spec_from_file_location(mod_name, path)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"could not load formula module {path}")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[mod_name] = module
+            spec.loader.exec_module(module)
+            formulas = getattr(module, "FORMULAS", None)
+            if not isinstance(formulas, dict):
+                raise RuntimeError(
+                    f"{path} defines no FORMULAS dict — an external formula module must export "
+                    "FORMULAS: Dict[str, Callable]"
+                )
+            for name, fn in formulas.items():
+                FUNCTION_REGISTRY[name] = fn
+
+
+_load_external_formulas()

--- a/tests/test_formula_path.py
+++ b/tests/test_formula_path.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""RDG_FORMULA_PATH — load formulas from outside the package.
+
+Contract:
+  - Every module in a RDG_FORMULA_PATH directory exporting `FORMULAS: Dict[str, Callable]`
+    is merged into FUNCTION_REGISTRY, and its formulas are callable from an .rdg file.
+  - Multiple directories are separated by os.pathsep.
+  - Modules starting with `_` are skipped; non-.py entries are ignored.
+  - Loading is FAIL-LOUD: a path that is not a directory, a module that will not import, or a
+    module without a FORMULAS dict raises rather than being skipped. Skipping would leave the
+    formula undefined and surface later as "unknown formula", sending the reader to their .rdg
+    to debug a typo that is not there.
+  - With the variable unset the registry is unchanged.
+
+Loading happens at import of functions.py, so these drive the real CLI in a subprocess: that
+exercises the actual wiring rather than calling the private loader directly.
+
+STRUCTURAL — no network, no LLM, no credentials.
+
+Run (use the project venv):
+  cd rdg-notebook/reactive-docgen
+  .venv/bin/python -m pytest tests/test_formula_path.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+FORMULA_MODULE = '''
+"""A formula defined outside the engine package."""
+
+def shout(rdg_file, **kwargs):
+    return "SHOUTED: " + kwargs.get("text", "").upper()
+
+FORMULAS = {"SHOUT": shout}
+'''
+
+
+def _run_cli(rdg_path: Path, formula_path: str | None):
+    env = dict(os.environ)
+    inherited = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(REPO) + (os.pathsep + inherited if inherited else "")
+    if formula_path is None:
+        env.pop("RDG_FORMULA_PATH", None)
+    else:
+        env["RDG_FORMULA_PATH"] = formula_path
+    return subprocess.run(
+        [sys.executable, "-m", "src.rdg.rdg_cli", str(rdg_path)],
+        cwd=REPO, env=env, capture_output=True, text=True,
+    )
+
+
+def _rdg(tmp_path: Path, body: str) -> Path:
+    (tmp_path / "out").mkdir(exist_ok=True)
+    rdg = tmp_path / "t.rdg"
+    rdg.write_text(body)
+    return rdg
+
+
+def test_external_formula_is_callable(tmp_path):
+    formulas = tmp_path / "formulas"
+    formulas.mkdir()
+    (formulas / "shout.py").write_text(FORMULA_MODULE)
+
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hello")\n')
+    proc = _run_cli(rdg, str(formulas))
+
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "out/a.md").read_text() == "SHOUTED: HELLO"
+
+
+def test_unset_leaves_the_formula_unknown(tmp_path):
+    """The same .rdg without the env var — proves the formula came from the path, not the engine."""
+    formulas = tmp_path / "formulas"
+    formulas.mkdir()
+    (formulas / "shout.py").write_text(FORMULA_MODULE)
+
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hello")\n')
+    proc = _run_cli(rdg, None)
+
+    # Asserted on the artifact and the message, not the exit code: an unknown formula mid-file
+    # still exits 0 on this branch. That is a separate parser defect, fixed in the per-line error
+    # isolation PR; asserting it here would make this test fail for a reason it does not own.
+    assert not (tmp_path / "out/a.md").exists()
+    assert "Unknown formula" in proc.stderr
+
+
+def test_multiple_directories(tmp_path):
+    one, two = tmp_path / "one", tmp_path / "two"
+    one.mkdir(), two.mkdir()
+    (one / "shout.py").write_text(FORMULA_MODULE)
+    (two / "whisper.py").write_text(
+        'def whisper(rdg_file, **kwargs):\n'
+        '    return "whispered: " + kwargs.get("text", "").lower()\n'
+        'FORMULAS = {"WHISPER": whisper}\n'
+    )
+
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hi")\nout/b.md=WHISPER(text="HI")\n')
+    proc = _run_cli(rdg, os.pathsep.join([str(one), str(two)]))
+
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "out/a.md").read_text() == "SHOUTED: HI"
+    assert (tmp_path / "out/b.md").read_text() == "whispered: hi"
+
+
+def test_underscore_modules_are_skipped(tmp_path):
+    formulas = tmp_path / "formulas"
+    formulas.mkdir()
+    (formulas / "shout.py").write_text(FORMULA_MODULE)
+    # A private helper with no FORMULAS dict. If it were loaded, fail-loud would raise and the
+    # valid module beside it would never register.
+    (formulas / "_helper.py").write_text("VALUE = 1\n")
+
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hi")\n')
+    proc = _run_cli(rdg, str(formulas))
+
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "out/a.md").read_text() == "SHOUTED: HI"
+
+
+def test_missing_directory_fails_loud(tmp_path):
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hi")\n')
+    proc = _run_cli(rdg, str(tmp_path / "does-not-exist"))
+
+    assert proc.returncode != 0
+    assert "RDG_FORMULA_PATH" in proc.stderr
+
+
+def test_module_without_formulas_dict_fails_loud(tmp_path):
+    formulas = tmp_path / "formulas"
+    formulas.mkdir()
+    (formulas / "broken.py").write_text("VALUE = 1\n")
+
+    rdg = _rdg(tmp_path, 'out/a.md=SHOUT(text="hi")\n')
+    proc = _run_cli(rdg, str(formulas))
+
+    assert proc.returncode != 0
+    assert "FORMULAS" in proc.stderr


### PR DESCRIPTION
Lets a project add its own formulas **without forking the engine**. Set the env var to one or more
directories; every module in them exporting a `FORMULAS` dict is merged into `FUNCTION_REGISTRY` at
import.

    RDG_FORMULA_PATH=/path/to/my/formulas rdg my.rdg

A formula module exports:

    FORMULAS: Dict[str, Callable]      # name -> f(rdg_file: str, **kwargs) -> str

which is exactly the signature `parser.py` already invokes — `formula(rdg_file, **arguments)` — whose
return value is written to the step's destination. No new calling convention.

## Why fail-loud

A path that does not exist, a module that will not import, or a module without a `FORMULAS` dict
**raises** rather than being skipped. Skipping would leave the formula undefined, and the failure
would resurface later as `Unknown formula` — sending the reader to their `.rdg` file to debug a typo
that is not there. The error should name the real cause at the real moment.

Modules prefixed with `_` are skipped by design, so a package can keep private helpers beside its
formula modules.

With the variable unset the registry is unchanged: 12 formulas, same as before.

## Tests

`tests/test_formula_path.py` — six structural cases, no network, no model call. Loading happens at
import, so each drives the real CLI in a subprocess; that exercises the actual wiring rather than
calling the private loader.

- an external formula is callable from an `.rdg` file
- the same `.rdg` with the variable **unset** does not produce the artifact — this is what proves the
  formula came from the path and not from the engine
- multiple directories, `os.pathsep` separated
- underscore-prefixed modules skipped
- a path that is not a directory fails loud
- a module without a `FORMULAS` dict fails loud

Verified as a real control rather than assumed: with the feature reverted, **5 of the 6 fail**. The
sixth is the unset case, which correctly passes either way.

Full suite on this branch: **68 passed, 1 skipped**.

## One honest note on a narrowed assertion

The unset case asserts on the artifact and stderr rather than the exit code, because an unknown
formula mid-file still exits **0** on this branch. That is a separate parser defect — it has its own
fix in #4 — and asserting it here would make this test fail for a reason it does not own. Worth
flagging that this test independently rediscovered that bug while being written.

## Base

Targets `feat/rdg-primary-claude` because this branch is built on it, so that base gives a
single-concern diff. Against `main` it would carry six unrelated commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
