### PR TITLE
feat(rdg): RDG_CACHE_DIR to choose the response cache location

### DIFF
--- a/src/rdg/config.py
+++ b/src/rdg/config.py
@@ -7,7 +7,14 @@ load_dotenv()
 LOG_FORMAT = '%(asctime)s - %(levelname)s - %(message)s'
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 
-CACHE_DIR = ".gemini_cache"
+# Response cache location. Relative by default, which means it lands in whatever directory the
+# process happened to start in — so two runs from different working directories silently use
+# different caches, and two unrelated runs from the same directory share one. A caller that wants
+# the cache scoped to something meaningful (a pipeline, a project) had no way to say so except by
+# choosing its cwd, which is a coarse instrument when the cwd is also where relative paths resolve.
+#
+# The default is unchanged, so existing behaviour is identical when the variable is unset.
+CACHE_DIR = os.environ.get("RDG_CACHE_DIR", ".gemini_cache")
 os.makedirs(CACHE_DIR, exist_ok=True)
 
 THROTTLE_SECONDS = 1

--- a/tests/test_cache_dir_env.py
+++ b/tests/test_cache_dir_env.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""RDG_CACHE_DIR — choose the response cache location explicitly.
+
+Contract:
+  - Unset, the cache directory is `.gemini_cache` relative to the process cwd (unchanged).
+  - Set, the cache directory is exactly that path, and nothing is created in the cwd.
+
+The directory is created at import of config.py, so these drive the real CLI in a subprocess with a
+cwd of their own: that is the behaviour being tested, and it keeps the repo free of stray caches.
+
+STRUCTURAL — no network, no LLM, no credentials.
+
+Run (use the project venv):
+  cd rdg-notebook/reactive-docgen
+  .venv/bin/python -m pytest tests/test_cache_dir_env.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _run_in(cwd: Path, cache_dir: str | None):
+    """Run a trivial deterministic pipeline with `cwd` as the process working directory."""
+    (cwd / "out").mkdir(exist_ok=True)
+    (cwd / "a.md").write_text("alpha\n")
+    rdg = cwd / "t.rdg"
+    rdg.write_text('out/a.md=FILESTOMARKDOWN(files="a.md")\n')
+
+    env = dict(os.environ)
+    inherited = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(REPO) + (os.pathsep + inherited if inherited else "")
+    if cache_dir is None:
+        env.pop("RDG_CACHE_DIR", None)
+    else:
+        env["RDG_CACHE_DIR"] = cache_dir
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "src.rdg.rdg_cli", str(rdg)],
+        cwd=cwd, env=env, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc
+
+
+def test_default_is_unchanged(tmp_path):
+    """Unset, the cache still lands in the cwd — this PR must not move anyone's cache."""
+    _run_in(tmp_path, None)
+    assert (tmp_path / ".gemini_cache").is_dir()
+
+
+def test_env_var_relocates_the_cache(tmp_path):
+    elsewhere = tmp_path / "chosen-cache"
+    _run_in(tmp_path, str(elsewhere))
+
+    assert elsewhere.is_dir(), "the cache should be created at the requested path"
+    assert not (tmp_path / ".gemini_cache").exists(), "nothing should be created in the cwd"
+
+
+def test_two_cwds_can_share_one_cache(tmp_path):
+    """The point of the variable: cache scope stops being an accident of where you started."""
+    shared = tmp_path / "shared-cache"
+    one, two = tmp_path / "one", tmp_path / "two"
+    one.mkdir(), two.mkdir()
+
+    _run_in(one, str(shared))
+    _run_in(two, str(shared))
+
+    assert shared.is_dir()
+    assert not (one / ".gemini_cache").exists()
+    assert not (two / ".gemini_cache").exists()


### PR DESCRIPTION
`CACHE_DIR` is a bare relative `".gemini_cache"`, so the cache lands wherever the process happened to
start. Two consequences, both silent:

- two runs from **different** working directories use **different** caches, and the resulting cache
  miss is indistinguishable from a first run
- two **unrelated** runs from the **same** directory **share** one cache

A caller who wants the cache scoped to something meaningful — a pipeline, a project — could only say
so by choosing its cwd. That is a coarse instrument, because the cwd is also where every relative
path in the `.rdg` resolves; you cannot move the cache without moving what the paths mean.

## Change

    CACHE_DIR = os.environ.get("RDG_CACHE_DIR", ".gemini_cache")

That is the pattern every other value in `config.py` already follows (`CLAUDE_CLI_PATH`,
`CLAUDE_CLI_MODEL`, `CLAUDE_CLI_TIMEOUT_SECONDS`, …). **The default is unchanged**, so behaviour is
identical when the variable is unset — this must not move anyone's existing cache.

## Tests

`tests/test_cache_dir_env.py` — three structural cases, no network, no model call. The directory is
created at import of `config.py`, so each drives the real CLI in a subprocess with a cwd of its own:
that is the behaviour under test, and it keeps the repo free of stray `.gemini_cache` directories.

- unset → the cache still lands in the cwd
- set → the cache is created at that path, and **nothing** is created in the cwd
- two different cwds can share one cache — the point of the variable

Verified as a real control rather than assumed: with the feature reverted, **2 of the 3 fail**. The
third is the default case, which correctly passes either way.

Full suite: **74 passed, 1 skipped**.

## Why I wanted it

Downstream I pin the cache per pipeline, which today means setting the child process's cwd to the
cache location and then resolving every `.rdg` path against a directory chosen for an unrelated
reason. With this, cache scope and path resolution stop being the same knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
