### PR TITLE
feat(rdg): RDG_JOBS — dependency-scheduled execution, serial-equivalent by construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,25 @@ Replace `sample.rdg` with the path to the `.rdg` file you want to validate. The 
 
 The tool is currently configured to use the `gemini-2.0-flash-exp` model. This can be changed in `src/rdg/gemini.py`.
 
+### Parallel execution (`RDG_JOBS`)
+
+Steps run top to bottom — that stays the authoring contract. `RDG_JOBS` lets the engine notice when
+line order over-serializes (five independent model calls in a row cost 5× wall clock) and run
+independent steps concurrently, without the author declaring anything:
+
+```bash
+RDG_JOBS=plan python -m src.rdg.rdg_cli my.rdg   # print the derived waves; execute nothing
+RDG_JOBS=4    python -m src.rdg.rdg_cli my.rdg   # run independent steps in dependency waves
+```
+
+Unset (or `1`), the serial loop runs exactly as always. The rules are mechanical: step B depends on
+step A when one of B's argument values names A's destination; formulas that read things their
+arguments do not name (the glob/directory walkers, and every `RDG_FORMULA_PATH` external formula)
+run as barriers; a duplicate destination, forward reference, or unparseable line makes the whole
+file fall back to serial, with the reason on stderr. A read-fence errors loudly if a step ever reads
+another step's destination without a dependency edge — a missed edge must never become a silent
+stale read. Artifacts are byte-identical to a serial run.
+
 ## License
 
 This project is licensed under the **GNU General Public License v3.0** (GPLv3).

--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -1,3 +1,4 @@
+import contextvars
 import os
 import glob as glob_module
 from pathlib import PurePath
@@ -7,8 +8,35 @@ from typing import Dict, Callable, Any
 import logging
 from ..llm.ollama import ollama_call
 
+# The read-fence, armed only by the RDG_JOBS wave runner (parser._run_step) and only for the
+# duration of one formula call. Serial execution never sets it, so serial behavior is untouched.
+#
+# It exists because a missed dependency edge in parallel mode does not crash: the consumer either
+# reads the previous run's stale bytes or — because destinations are deleted before their producer
+# writes — finds nothing and this function returns the path itself as literal text, which a model
+# then answers fluently. Both produce a plausible artifact that exits 0 and poisons the cache.
+# The fence turns that silence into a named error at the exact moment of the read: a step touching
+# ANY step's destination that is not among its declared ancestors is a scheduling bug, reported as
+# reader, writer, and the missing edge.
+#
+# Coverage is process_input only — the choke point through which every KNOWN_SAFE formula resolves
+# path-valued arguments. Formulas outside KNOWN_SAFE run as barriers with nothing else in flight,
+# so their unfenced reads cannot race.
+_READ_FENCE = contextvars.ContextVar("rdg_read_fence", default=None)
+
+
 def process_input(input_arg, file_dir):
     file_path = os.path.join(file_dir, input_arg)
+    fence = _READ_FENCE.get()
+    if fence is not None:
+        all_dests, allowed, reader = fence
+        normalized = os.path.normpath(file_path)
+        if normalized in all_dests and normalized not in allowed:
+            raise RdgParserError(
+                f"read fence: {reader} read '{input_arg}', which is written by "
+                f"{all_dests[normalized]} with no dependency edge between them. "
+                f"The parallel plan missed this edge; running serially is safe."
+            )
     logging.info(f"Checking for file: {file_path}")
     if os.path.exists(file_path):
         with open(file_path, 'r') as f:

--- a/src/rdg/parser.py
+++ b/src/rdg/parser.py
@@ -1,8 +1,9 @@
 import re
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from .functions import FUNCTION_REGISTRY, RdgParserError
+from .functions import FUNCTION_REGISTRY, RdgParserError, _READ_FENCE
 
 def parse_rdg_line(line: str, file_dir: str = ".") -> tuple[str, str, dict[str, Any]]:
     """Parses a single line of the rdg file."""
@@ -50,52 +51,77 @@ def parse_rdg_line(line: str, file_dir: str = ".") -> tuple[str, str, dict[str, 
     return output_file, formula_name, arguments
 
 
+def _run_step(rdg_file: str, file_dir: str, line: str, fence=None) -> int:
+    """Execute one line of an rdg file. Returns 1 if the step failed, else 0.
+
+    This is the serial loop body, extracted verbatim so the serial path and the RDG_JOBS wave
+    runner share one implementation — per-step semantics (parse inside the try, delete the
+    destination before the formula runs, write ## ERROR into the step's own destination on
+    failure) cannot drift between the two.
+
+    `fence` is only ever set by the parallel runner: (all_destinations, allowed_destinations,
+    step_label). It arms the read-fence in process_input for the duration of the formula call.
+    ContextVars are per-thread, and this runs inside the worker thread, so arming it here
+    scopes it to exactly this step.
+    """
+    output_path = None
+    try:
+        output_file, formula_name, arguments = parse_rdg_line(line, file_dir)
+        if not output_file:  # skip empty lines or comments
+            return 0
+
+        # Resolved before the formula is looked up, so the error handlers always have a
+        # path to write to. An unknown formula used to raise KeyError here, and the
+        # handler then raised UnboundLocalError on output_path, aborting the file.
+        output_path = os.path.join(file_dir, output_file)
+        formula = FUNCTION_REGISTRY[formula_name]
+
+        # Create the output directory if it doesn't exist
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        # Delete the output file if it exists
+        if os.path.exists(output_path):
+            os.remove(output_path)
+
+        if fence is not None:
+            token = _READ_FENCE.set(fence)
+            try:
+                result = formula(rdg_file, **arguments)
+            finally:
+                _READ_FENCE.reset(token)
+        else:
+            result = formula(rdg_file, **arguments)
+
+        with open(output_path, 'w') as outfile:
+            outfile.write(result)
+        return 0
+    except KeyError as e:
+        print(f"Unknown formula on line '{line.strip()}': {e}", file=sys.stderr)
+        _write_error(output_path, f"Unknown formula: {e}")
+        return 1
+    except RdgParserError as e:
+        print(f"Error processing line '{line.strip()}': {e}", file=sys.stderr)
+        _write_error(output_path, e)
+        return 1
+    except Exception as e:
+        print(f"An unexpected error occurred processing line '{line.strip()}': {e}", file=sys.stderr)
+        _write_error(output_path, e)
+        return 1
+
+
 def process_rdg_file(rdg_file: str, file_dir: str = ".") -> int:
     """Process the given rdg file. Returns the number of steps that failed."""
     failures = 0
     try:
         with open(rdg_file, 'r') as f:
             for line in f:
-                # Parsing happens INSIDE the per-line try. Outside it, a single malformed line or
-                # unknown formula raised past the loop to the file-level handler below, which
-                # silently abandoned every remaining line — and the CLI still reported success.
-                output_path = None
-                try:
-                    output_file, formula_name, arguments = parse_rdg_line(line, file_dir)
-                    if not output_file:  # skip empty lines or comments
-                        continue
-
-                    # Resolved before the formula is looked up, so the error handlers always have a
-                    # path to write to. An unknown formula used to raise KeyError here, and the
-                    # handler then raised UnboundLocalError on output_path, aborting the file.
-                    output_path = os.path.join(file_dir, output_file)
-                    formula = FUNCTION_REGISTRY[formula_name]
-
-                    # Create the output directory if it doesn't exist
-                    output_dir = os.path.dirname(output_path)
-                    if output_dir and not os.path.exists(output_dir):
-                        os.makedirs(output_dir, exist_ok=True)
-
-                    # Delete the output file if it exists
-                    if os.path.exists(output_path):
-                        os.remove(output_path)
-
-                    result = formula(rdg_file, **arguments)
-
-                    with open(output_path, 'w') as outfile:
-                        outfile.write(result)
-                except KeyError as e:
-                    failures += 1
-                    print(f"Unknown formula on line '{line.strip()}': {e}", file=sys.stderr)
-                    _write_error(output_path, f"Unknown formula: {e}")
-                except RdgParserError as e:
-                    failures += 1
-                    print(f"Error processing line '{line.strip()}': {e}", file=sys.stderr)
-                    _write_error(output_path, e)
-                except Exception as e:
-                    failures += 1
-                    print(f"An unexpected error occurred processing line '{line.strip()}': {e}", file=sys.stderr)
-                    _write_error(output_path, e)
+                # Parsing happens INSIDE the per-line try (in _run_step). Outside it, a single
+                # malformed line or unknown formula raised past the loop to the file-level handler
+                # below, which silently abandoned every remaining line — and the CLI still
+                # reported success.
+                failures += _run_step(rdg_file, file_dir, line)
     except FileNotFoundError:
         print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
         return 1
@@ -118,3 +144,183 @@ def _write_error(output_path, error):
             outfile.write(f"## ERROR\n\n{error}\n")
     except OSError as exc:
         print(f"Could not write error to '{output_path}': {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# RDG_JOBS — dependency-scheduled execution
+# ---------------------------------------------------------------------------
+#
+# Top-to-bottom stays the AUTHORING contract: a step that gathers is written above the step that
+# consumes it, and that is all an author ever has to know. What follows lets the ENGINE notice when
+# line order over-serializes — five independent model calls in a row cost 5x wall clock for no
+# reason — and run independent steps concurrently, without the author declaring anything.
+#
+# Opt-in via RDG_JOBS=N (see rdg_cli.py). Unset, the serial loop above runs untouched.
+#
+# The rules are purely mechanical, and everything they cannot prove falls back to the serial loop:
+#
+#   EDGE      step j depends on step i when one of j's argument values (split on commas, each piece
+#             path-normalized) equals i's normalized destination. That is exactly the join the
+#             engine itself performs at run time: process_input resolves an argument against the
+#             file's directory and reads it if it exists.
+#   BARRIER   a step whose formula is not in KNOWN_SAFE runs alone — after everything before it,
+#             before everything after it. KNOWN_SAFE holds only formulas verified to read the
+#             filesystem exclusively through paths named in their argument values. Everything else
+#             — the glob/directory walkers, and every externally loaded formula — reads things its
+#             arguments do not name, so its true edges are unknowable from the text.
+#   REFUSE    a duplicate destination, a forward reference (an argument naming a LATER step's
+#             destination), or any unparseable line -> the whole file runs serially, with the
+#             reason on stderr. Serial has defined semantics for all three; a reordering does not.
+#
+# Every edge goes from a lower index to a higher one and forward references are refused, so the
+# graph is acyclic by construction — there is no cycle detection because no cycle can be built.
+#
+# WHY THE CAUTION IS NOT OPTIONAL. A missed edge here does not crash. The engine deletes a
+# destination before writing it, and process_input treats a nonexistent path as literal text — so
+# a consumer scheduled before its producer either reads the previous run's stale bytes or pastes
+# the path string itself into a prompt, gets a fluent answer, exits 0, and caches the wrong result
+# under the wrong prompt. GNU Make shipped parallel builds in the 1980s and its missed-edge
+# detector (--shuffle) in 2022; the fence in process_input ships here in the same commit.
+
+KNOWN_SAFE = {
+    "FILESTOMARKDOWN", "GEMINIPROMPT", "GEMINIPROMPTFILE", "CREATEFILE",
+    "CREATEGEMINIPROMPT", "SUMMARIZE", "UPPERCASE",
+}
+
+
+def plan_rdg_file(rdg_file: str, file_dir: str = "."):
+    """Derive the wave plan for a file, or the reason it must run serially.
+
+    Returns (steps, waves, edges, reason). `reason` is None when the plan is usable; otherwise it
+    says why the file falls back to the serial loop, and the other fields describe what WAS parsed.
+    steps: list of dicts {index, line, dest, norm, formula}. waves: list of lists of step indexes.
+    edges: set of (i, j) pairs meaning i must complete before j starts.
+    """
+    def norm(p):
+        return os.path.normpath(os.path.join(file_dir, p))
+
+    steps = []
+    with open(rdg_file, 'r') as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            try:
+                dest, formula_name, arguments = parse_rdg_line(raw, file_dir)
+            except RdgParserError as e:
+                return steps, [], set(), f"line will not parse ({e})"
+            if not dest:
+                continue
+            steps.append({
+                "index": len(steps), "line": raw, "dest": dest, "norm": norm(dest),
+                "formula": formula_name, "args": arguments,
+            })
+
+    by_norm = {}
+    for s in steps:
+        if s["norm"] in by_norm:
+            return steps, [], set(), f"duplicate destination '{s['dest']}'"
+        by_norm[s["norm"]] = s["index"]
+
+    edges = set()
+    for s in steps:
+        for value in s["args"].values():
+            for piece in str(value).split(","):
+                piece = piece.strip()
+                if not piece:
+                    continue
+                producer = by_norm.get(norm(piece))
+                if producer is None or producer == s["index"]:
+                    continue
+                if producer > s["index"]:
+                    return steps, [], set(), (
+                        f"forward reference: step {s['index'] + 1} reads '{piece}', "
+                        f"written by later step {producer + 1}"
+                    )
+                edges.add((producer, s["index"]))
+
+    for s in steps:
+        if s["formula"] not in KNOWN_SAFE:
+            for other in steps:
+                if other["index"] < s["index"]:
+                    edges.add((other["index"], s["index"]))
+                elif other["index"] > s["index"]:
+                    edges.add((s["index"], other["index"]))
+
+    # Kahn layering. Acyclic by construction (every edge goes forward), so this always terminates.
+    preds = {s["index"]: set() for s in steps}
+    for i, j in edges:
+        preds[j].add(i)
+    waves, placed = [], set()
+    while len(placed) < len(steps):
+        wave = [i for i in preds if i not in placed and preds[i] <= placed]
+        waves.append(sorted(wave))
+        placed.update(wave)
+
+    return steps, waves, edges, None
+
+
+def print_plan(rdg_file: str, file_dir: str = ".") -> int:
+    """RDG_JOBS=plan — show what would run in which wave. Executes nothing, writes nothing."""
+    try:
+        steps, waves, edges, reason = plan_rdg_file(rdg_file, file_dir)
+    except FileNotFoundError:
+        print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
+        return 1
+    if reason is not None:
+        print(f"serial fallback: {reason}")
+        return 0
+    preds = {s["index"]: sorted(i for i, j in edges if j == s["index"]) for s in steps}
+    for w, wave in enumerate(waves):
+        print(f"wave {w}:")
+        for i in wave:
+            s = steps[i]
+            kind = "safe" if s["formula"] in KNOWN_SAFE else "barrier"
+            after = f"  after {[p + 1 for p in preds[i]]}" if preds[i] else ""
+            print(f"  step {i + 1}  {s['formula']:<16} -> {s['dest']}  [{kind}]{after}")
+    return 0
+
+
+def process_rdg_file_parallel(rdg_file: str, file_dir: str = ".", jobs: int = 2) -> int:
+    """Wave-scheduled execution. Falls back to the serial loop whenever the plan cannot be proven.
+
+    Semantics are the serial loop's, re-ordered only where the plan proves independence: the same
+    _run_step body, a failed step still writes ## ERROR into its own destination, and its
+    dependents still run afterward and read those bytes — exactly as they would serially.
+    """
+    try:
+        steps, waves, edges, reason = plan_rdg_file(rdg_file, file_dir)
+    except FileNotFoundError:
+        print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}", file=sys.stderr)
+        return 1
+    if reason is not None:
+        print(f"RDG_JOBS: serial fallback — {reason}", file=sys.stderr)
+        return process_rdg_file(rdg_file, file_dir)
+
+    # For the read-fence: what each step is ALLOWED to read is its transitive predecessors'
+    # destinations (plus its own, which it just deleted). Reading any OTHER step's destination
+    # means the edge inference missed a dependency — that must be loud, never a stale read.
+    ancestors = {s["index"]: set() for s in steps}
+    for wave in waves:
+        for j in wave:
+            for i, k in edges:
+                if k == j:
+                    ancestors[j].add(i)
+                    ancestors[j] |= ancestors[i]
+    all_dests = {s["norm"]: f"step {s['index'] + 1} ({s['dest']})" for s in steps}
+
+    failures = 0
+    with ThreadPoolExecutor(max_workers=max(2, jobs)) as pool:
+        for wave in waves:
+            futures = []
+            for i in wave:
+                s = steps[i]
+                allowed = {steps[a]["norm"] for a in ancestors[i]} | {s["norm"]}
+                fence = (all_dests, allowed, f"step {i + 1} ({s['dest']})")
+                futures.append(pool.submit(_run_step, rdg_file, file_dir, s["line"], fence))
+            for fut in futures:
+                failures += fut.result()
+    return failures

--- a/src/rdg/rdg_cli.py
+++ b/src/rdg/rdg_cli.py
@@ -1,14 +1,24 @@
 import sys
 import os
-from .parser import process_rdg_file
+from .parser import process_rdg_file, process_rdg_file_parallel, print_plan
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: rdg.py <rdg_file>", file=sys.stderr)
         sys.exit(1)
-    
+
     rdg_file = sys.argv[1]
     file_dir = os.path.dirname(os.path.abspath(rdg_file))  # get folder of rdg file
-    failures = process_rdg_file(rdg_file, file_dir)
+
+    # RDG_JOBS opts into dependency-scheduled execution (see parser.py). Unset or 1, the serial
+    # loop runs exactly as it always has. "plan" prints the derived waves and executes nothing.
+    jobs_env = os.environ.get("RDG_JOBS", "").strip()
+    if jobs_env == "plan":
+        sys.exit(print_plan(rdg_file, file_dir))
+    jobs = int(jobs_env) if jobs_env.isdigit() else 1
+    if jobs > 1:
+        failures = process_rdg_file_parallel(rdg_file, file_dir, jobs)
+    else:
+        failures = process_rdg_file(rdg_file, file_dir)
     if failures:
         print(f"Rdg file processed with {failures} failed step(s)", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_parallel_jobs.py
+++ b/tests/test_parallel_jobs.py
@@ -1,0 +1,213 @@
+"""RDG_JOBS — dependency-scheduled execution must be a provable reordering of serial, or serial.
+
+Contract under test:
+  - RDG_JOBS unset: byte-identical serial behavior (the loop object code is untouched).
+  - RDG_JOBS=N: steps run in dependency waves; artifacts are byte-identical to a serial run.
+  - RDG_JOBS=plan: prints the waves, executes nothing, writes nothing.
+  - Anything unprovable — duplicate destination, forward reference, unparseable line — falls back
+    to the serial loop, loudly, with the reason on stderr.
+  - A failed step's dependents still run and read its ## ERROR bytes (parity with the serial loop).
+  - The read-fence raises the moment a step reads another step's destination without an edge.
+
+Hermetic: deterministic formulas only, no network, no model call.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run(tmp, rdg_body, files, jobs=None):
+    for name, content in files.items():
+        path = os.path.join(tmp, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as handle:
+            handle.write(content)
+    rdg = os.path.join(tmp, "t.rdg")
+    with open(rdg, "w") as handle:
+        handle.write(rdg_body)
+    env = dict(os.environ)
+    inherited = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = REPO + (os.pathsep + inherited if inherited else "")
+    if jobs is None:
+        env.pop("RDG_JOBS", None)
+    else:
+        env["RDG_JOBS"] = str(jobs)
+    return subprocess.run(
+        [sys.executable, "-m", "src.rdg.rdg_cli", rdg],
+        cwd=REPO, env=env, capture_output=True, text=True,
+    )
+
+
+def _artifacts(tmp):
+    out = {}
+    for root, _dirs, names in os.walk(os.path.join(tmp, "out")):
+        for n in names:
+            p = os.path.join(root, n)
+            out[os.path.relpath(p, tmp)] = open(p).read()
+    return out
+
+
+# The review.rdg shape: independent gather->consume pairs chained only by destination strings.
+# CREATEFILE renders {{placeholders}} from its other args, each resolved by process_input — so
+# consumer content proves it read the producer's FRESH bytes, not a stale or absent file.
+CHAIN = (
+    'out/a.md=FILESTOMARKDOWN(files="src_a.md")\n'
+    'out/b.md=FILESTOMARKDOWN(files="src_b.md")\n'
+    'out/ca.md=CREATEFILE(content="consumed:{{x}}", x=out/a.md)\n'
+    'out/cb.md=CREATEFILE(content="consumed:{{x}}", x=out/b.md)\n'
+)
+CHAIN_FILES = {"src_a.md": "alpha-marker\n", "src_b.md": "beta-marker\n"}
+
+
+class GoldenSerialEqualsParallel(unittest.TestCase):
+    def test_artifacts_byte_identical_and_fresh(self):
+        t1 = tempfile.mkdtemp()
+        serial = _run(t1, CHAIN, CHAIN_FILES)
+        self.assertEqual(serial.returncode, 0, serial.stderr)
+        golden = _artifacts(t1)
+
+        t2 = tempfile.mkdtemp()
+        parallel = _run(t2, CHAIN, CHAIN_FILES, jobs=4)
+        self.assertEqual(parallel.returncode, 0, parallel.stderr)
+        self.assertEqual(golden, _artifacts(t2), "parallel must be a reordering, not a rewrite")
+
+        # Wave correctness: the consumer embedded the producer's marker, so it read fresh bytes.
+        self.assertIn("alpha-marker", golden["out/ca.md"])
+        self.assertIn("beta-marker", golden["out/cb.md"])
+        self.assertNotIn("out/a.md", golden["out/ca.md"], "a pasted path means the read raced the write")
+
+
+class RefuseToSerial(unittest.TestCase):
+    def test_forward_reference_falls_back(self):
+        body = (
+            'out/first.md=CREATEFILE(content="{{x}}", x=out/second.md)\n'
+            'out/second.md=FILESTOMARKDOWN(files="src_a.md")\n'
+        )
+        t = tempfile.mkdtemp()
+        parallel = _run(t, body, CHAIN_FILES, jobs=4)
+        self.assertIn("serial fallback", parallel.stderr)
+        self.assertIn("forward reference", parallel.stderr)
+        t2 = tempfile.mkdtemp()
+        serial = _run(t2, body, CHAIN_FILES)
+        self.assertEqual(_artifacts(t), _artifacts(t2), "fallback must equal plain serial")
+
+    def test_duplicate_destination_falls_back(self):
+        body = (
+            'out/x.md=FILESTOMARKDOWN(files="src_a.md")\n'
+            'out/x.md=FILESTOMARKDOWN(files="src_b.md")\n'
+        )
+        t = tempfile.mkdtemp()
+        parallel = _run(t, body, CHAIN_FILES, jobs=4)
+        self.assertIn("duplicate destination", parallel.stderr)
+        t2 = tempfile.mkdtemp()
+        serial = _run(t2, body, CHAIN_FILES)
+        self.assertEqual(_artifacts(t), _artifacts(t2))
+
+
+class Barriers(unittest.TestCase):
+    def test_walker_is_a_barrier_in_the_plan(self):
+        body = (
+            'out/a.md=FILESTOMARKDOWN(files="src_a.md")\n'
+            'out/g.md=GLOBTOMARKDOWN(pattern="src_*.md")\n'
+            'out/b.md=FILESTOMARKDOWN(files="src_b.md")\n'
+        )
+        t = tempfile.mkdtemp()
+        plan = _run(t, body, CHAIN_FILES, jobs="plan")
+        self.assertEqual(plan.returncode, 0, plan.stderr)
+        self.assertIn("[barrier]", plan.stdout)
+        # Three waves: the barrier fences its neighbours into separate waves.
+        self.assertIn("wave 2:", plan.stdout)
+        # plan mode executes nothing
+        self.assertFalse(os.path.exists(os.path.join(t, "out")), "plan mode must not write")
+
+    def test_barrier_execution_is_ordered_around(self):
+        # The glob step must see BOTH earlier destinations if they matched its pattern — here it
+        # globs the sources, so the assertion is simply byte-parity with serial.
+        body = (
+            'out/a.md=FILESTOMARKDOWN(files="src_a.md")\n'
+            'out/g.md=GLOBTOMARKDOWN(pattern="src_*.md")\n'
+            'out/b.md=FILESTOMARKDOWN(files="src_b.md")\n'
+        )
+        t1, t2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        serial = _run(t1, body, CHAIN_FILES)
+        parallel = _run(t2, body, CHAIN_FILES, jobs=4)
+        self.assertEqual(serial.returncode, 0, serial.stderr)
+        self.assertEqual(parallel.returncode, 0, parallel.stderr)
+        self.assertEqual(_artifacts(t1), _artifacts(t2))
+
+
+class FailureParity(unittest.TestCase):
+    def test_failed_steps_dependents_still_run(self):
+        # Step 1 fails at RUN time (unmatched template placeholder — the parse is fine, so the
+        # file genuinely plans and runs in waves rather than falling back). Its handler writes
+        # ## ERROR into its own destination; step 2 depends on that destination and must still
+        # run, reading the error bytes — exactly the serial contract from the error-isolation PR.
+        body = (
+            'out/bad.md=CREATEFILE(content="{{missing}}", x=src_a.md)\n'
+            'out/consumer.md=CREATEFILE(content="got:{{x}}", x=out/bad.md)\n'
+        )
+        t1, t2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        serial = _run(t1, body, CHAIN_FILES)
+        parallel = _run(t2, body, CHAIN_FILES, jobs=4)
+        self.assertEqual(serial.returncode, 1)
+        self.assertEqual(parallel.returncode, 1)
+        # a real plan ran — no fallback notice
+        self.assertNotIn("serial fallback", parallel.stderr)
+        self.assertEqual(_artifacts(t1), _artifacts(t2))
+        self.assertIn("## ERROR", _artifacts(t2)["out/consumer.md"])
+
+    def test_unknown_formula_is_a_parse_failure_and_falls_back(self):
+        # An unknown formula fails at PARSE, so the plan cannot be built: parallel mode must fall
+        # back to the serial loop and reproduce its exact semantics (no destination written; a
+        # consumer receives the literal path string, because that is what process_input does with
+        # a nonexistent file).
+        body = (
+            'out/bad.md=NOSUCHFORMULA(files="src_a.md")\n'
+            'out/consumer.md=CREATEFILE(content="{{x}}", x=out/bad.md)\n'
+        )
+        t1, t2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        serial = _run(t1, body, CHAIN_FILES)
+        parallel = _run(t2, body, CHAIN_FILES, jobs=4)
+        self.assertEqual(serial.returncode, 1)
+        self.assertEqual(parallel.returncode, 1)
+        self.assertIn("serial fallback", parallel.stderr)
+        self.assertEqual(_artifacts(t1), _artifacts(t2))
+        self.assertEqual(_artifacts(t2)["out/consumer.md"], "out/bad.md")
+
+
+class ReadFence(unittest.TestCase):
+    def test_fence_raises_on_unedged_read(self):
+        # Unit-level: arm the fence the way _run_step does, then read a destination that is not in
+        # the allowed set. This is the detector for an edge the inference missed.
+        sys.path.insert(0, REPO)
+        from src.rdg.functions import process_input, _READ_FENCE, RdgParserError
+        tmp = tempfile.mkdtemp()
+        dest = os.path.join(tmp, "out", "a.md")
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as handle:
+            handle.write("bytes")
+        fence = ({os.path.normpath(dest): "step 1 (out/a.md)"}, set(), "step 2 (out/b.md)")
+        token = _READ_FENCE.set(fence)
+        try:
+            with self.assertRaises(RdgParserError) as ctx:
+                process_input("out/a.md", tmp)
+            self.assertIn("step 2", str(ctx.exception))
+            self.assertIn("step 1", str(ctx.exception))
+        finally:
+            _READ_FENCE.reset(token)
+        # And with the edge present, the same read succeeds.
+        fence_ok = ({os.path.normpath(dest): "step 1 (out/a.md)"}, {os.path.normpath(dest)}, "step 2")
+        token = _READ_FENCE.set(fence_ok)
+        try:
+            self.assertEqual(process_input("out/a.md", tmp), "bytes")
+        finally:
+            _READ_FENCE.reset(token)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Steps run top to bottom — **that stays the authoring contract**, and it is all an author ever has to
know. This PR lets the *engine* notice when line order over-serializes and run independent steps
concurrently. Opt-in, nothing declared by the author, and everything the rules cannot prove falls
back to the serial loop, loudly.

```bash
RDG_JOBS=plan python -m src.rdg.rdg_cli my.rdg   # print the derived waves; execute nothing
RDG_JOBS=4    python -m src.rdg.rdg_cli my.rdg   # run independent steps in dependency waves
```

Unset (or `1`): the serial loop runs untouched.

## Measured motivation

A real 10-step pipeline — 5 gathers then 5 model reviews, review *i* reading only gather *i* — cost
**1,184s** serially where **~340s** was available (critical depth 2). Its owner hand-split it into
five files to collect the speedup; this makes that authoring burden unnecessary. It is also what the
README's own metaphor promises: *"like a spreadsheet for files"* — spreadsheets evaluate in
dependency order, not top to bottom.

## Mechanics — purely algorithmic, no heuristics

- **Edge:** step B depends on step A when one of B's argument values (comma-split, path-normalized)
  equals A's normalized destination — the same join `process_input` performs at run time.
- **Barrier:** any formula not in `KNOWN_SAFE` runs alone (after everything before it, before
  everything after it). `KNOWN_SAFE` holds only formulas verified to read the filesystem exclusively
  through paths named in their argument values; the glob/directory walkers and every
  `RDG_FORMULA_PATH` external formula are barriers by this one rule.
- **Refuse-to-serial, loudly:** duplicate destination, forward reference, unparseable line. Serial
  has defined semantics for all three; a reordering does not.
- **Waves:** Kahn layering on a `ThreadPoolExecutor` (calls are I/O-bound). Every edge goes from a
  lower line to a higher one and forward refs are refused, so the graph is **acyclic by
  construction** — there is no cycle detection because no cycle can be built.
- **One step executor:** the serial loop body is extracted verbatim into `_run_step` and both paths
  call it, so per-step semantics — delete-before-write, `## ERROR` into the failing step's own
  destination, dependents still running — cannot drift.

## Why the read-fence ships in the same commit

A missed edge here does not crash. The engine deletes a destination before writing it, and
`process_input` treats a nonexistent path as literal text — so a mis-scheduled consumer either reads
stale bytes or pastes the path itself into a prompt, gets a fluent answer, exits 0, **and caches the
wrong result under the wrong prompt**. GNU Make shipped `-j` in the 1980s and its missed-edge
detector (`--shuffle`) in 2022 — which immediately found bugs in dozens of mature packages.

So the detector ships with the feature: in parallel mode, a step reading **any** step's destination
that is not among its declared ancestors raises immediately, naming reader, writer, and the missing
edge. Serial mode never arms it — zero behavior change.

## Tests

`tests/test_parallel_jobs.py` — hermetic, deterministic formulas only, no model calls:

- golden: serial and `RDG_JOBS=4` artifacts **byte-identical** on the review shape; consumer content
  carries the producer's marker, proving fresh reads
- forward reference and duplicate destination → serial fallback whose artifacts equal plain serial
- a walker between two safe steps is planned into its own wave; `plan` mode writes nothing
- a step that fails at **run** time under a real plan (not a fallback) still has its dependents run
  and read its `## ERROR` bytes — parity with the error-isolation semantics from #4
- the fence raises naming both steps; with the edge present the same read succeeds

Verified as a real control: **5 of 8 fail against main's engine** (the three passers are
serial-parity cases, correctly indifferent). Full suite: **82 passed, 1 skipped**.

Live proof on a real corpus: `plan` correctly barriers an external `DIGESTMANIFEST` between a walker
and a model step; four `CREATEFILE`s form one 4-wide wave; a real `RDG_JOBS=4` run produced
artifacts **byte-identical** to the serial run of the same file.

## Deliberately out (decisions, not omissions)

- verify-mode (parallel-then-serial replay compare) — the golden covers the invariant in CI
- priority scheduling / global model-call semaphore — at depth 2, FIFO waves collect the full win
- walker scope-analysis — barriers cost milliseconds; the prize is the model steps
- author-declared dependency syntax — refused; that is hand-splitting with extra grammar
- temp+rename atomic writes, stderr line-tagging — benign under sound edges; happy to follow up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
