### PR TITLE
docs(rdg): CREATEFILE docstring — the template contract and the faithful-copy idiom

### DIFF
--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -146,14 +146,12 @@ def uppercase(rdg_file:str, **kwargs) -> str:
     
 def create_file(rdg_file:str, **kwargs) -> str:
     """
-    Creates a file by rendering a template string.
+    Creates a file by rendering a template. To copy a file byte-faithfully use exactly
+    dest=CREATEFILE(content="{{src}}", src=path/to/file) — content is a TEMPLATE and is never
+    path-resolved (content=path/to/file writes the literal path string as the artifact), while
+    every other argument IS path-resolved, so src= carries the file's text into the template.
 
-    content=  the TEMPLATE. Never path-resolved: content=path/to/file writes the literal
-              text "path/to/file", not the file. Placeholders {{name}} are filled from
-              the other arguments.
-    (other)=  path-resolved: an argument naming an existing file becomes that file's text.
-
-    To copy a file byte-faithfully: destination=CREATEFILE(content="{{src}}", src=path/to/file)
+    content=  the template; {{name}} placeholders are filled from the other arguments
     """
     
     

--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -146,11 +146,14 @@ def uppercase(rdg_file:str, **kwargs) -> str:
     
 def create_file(rdg_file:str, **kwargs) -> str:
     """
-    Creates a file with a given string.
-    
-    Args:
-    rdg_file (str): Path to the rdg file
-    content (str): content of the file to be created
+    Creates a file by rendering a template string.
+
+    content=  the TEMPLATE. Never path-resolved: content=path/to/file writes the literal
+              text "path/to/file", not the file. Placeholders {{name}} are filled from
+              the other arguments.
+    (other)=  path-resolved: an argument naming an existing file becomes that file's text.
+
+    To copy a file byte-faithfully: destination=CREATEFILE(content="{{src}}", src=path/to/file)
     """
     
     


### PR DESCRIPTION
content= is a TEMPLATE, never path-resolved; every other argument IS. `CREATEFILE(content=path/to/file)` writes the literal path string, verifies clean, and is wrong — this bit a real pipeline and was caught only by a downstream digest comparison.

The docstring is load-bearing: `FORMULACATALOGUE` publishes it into consumers' catalogues, so it is the one place a copyable correct example (`content="{{src}}", src=…`) reaches authors. LLM authors copy examples over prose — the example must be safe to copy verbatim.

Suite: 82 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)