### PR TITLE
fix(template): tolerate whitespace inside mustache braces

### DIFF
--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -146,14 +146,12 @@ def uppercase(rdg_file:str, **kwargs) -> str:
     
 def create_file(rdg_file:str, **kwargs) -> str:
     """
-    Creates a file by rendering a template string.
+    Creates a file by rendering a template. To copy a file byte-faithfully use exactly
+    dest=CREATEFILE(content="{{src}}", src=path/to/file) — content is a TEMPLATE and is never
+    path-resolved (content=path/to/file writes the literal path string as the artifact), while
+    every other argument IS path-resolved, so src= carries the file's text into the template.
 
-    content=  the TEMPLATE. Never path-resolved: content=path/to/file writes the literal
-              text "path/to/file", not the file. Placeholders {{name}} are filled from
-              the other arguments.
-    (other)=  path-resolved: an argument naming an existing file becomes that file's text.
-
-    To copy a file byte-faithfully: destination=CREATEFILE(content="{{src}}", src=path/to/file)
+    content=  the template; {{name}} placeholders are filled from the other arguments
     """
     
     

--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -146,11 +146,14 @@ def uppercase(rdg_file:str, **kwargs) -> str:
     
 def create_file(rdg_file:str, **kwargs) -> str:
     """
-    Creates a file with a given string.
-    
-    Args:
-    rdg_file (str): Path to the rdg file
-    content (str): content of the file to be created
+    Creates a file by rendering a template string.
+
+    content=  the TEMPLATE. Never path-resolved: content=path/to/file writes the literal
+              text "path/to/file", not the file. Placeholders {{name}} are filled from
+              the other arguments.
+    (other)=  path-resolved: an argument naming an existing file becomes that file's text.
+
+    To copy a file byte-faithfully: destination=CREATEFILE(content="{{src}}", src=path/to/file)
     """
     
     

--- a/src/rdg/template.py
+++ b/src/rdg/template.py
@@ -2,7 +2,12 @@ import re
 from string import Template
 
 # Mustache-style pattern: matches {{variable_name}}
-_MUSTACHE_RE = re.compile(r'\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}')
+# Whitespace inside the braces is tolerated: {{name}} and {{ name }} are the same placeholder.
+# The strict form silently DID NOT MATCH a spaced placeholder, so {{ src }} rendered as its own
+# literal text — a template that looked one character-class away from correct produced a wrong
+# artifact that verified clean. An LLM authoring loop failed to converge on that difference across
+# four passes; a human squints at it too. Postel's law, scoped to whitespace only.
+_MUSTACHE_RE = re.compile(r'\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}')
 
 def render_template(template_str, input_data):
     """Render template by replacing placeholders with input_data values.

--- a/tests/test_template_whitespace.py
+++ b/tests/test_template_whitespace.py
@@ -1,0 +1,27 @@
+"""{{ name }} and {{name}} are the same placeholder.
+
+The strict pattern silently skipped spaced placeholders, so a template one whitespace away from
+correct rendered its own literal text as the artifact — and verified clean. Hermetic.
+"""
+import os, sys, unittest
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.rdg.template import render_template
+
+
+class WhitespaceTolerantMustache(unittest.TestCase):
+    def test_spaced_and_tight_are_the_same_placeholder(self):
+        self.assertEqual(render_template("{{name}}", {"name": "X"}), "X")
+        self.assertEqual(render_template("{{ name }}", {"name": "X"}), "X")
+        self.assertEqual(render_template("{{  name  }}", {"name": "X"}), "X")
+
+    def test_unknown_spaced_placeholder_raises_like_tight(self):
+        with self.assertRaises(ValueError):
+            render_template("{{ missing }}", {"name": "X"})
+
+    def test_replacement_text_is_not_rescanned(self):
+        # A substituted value containing a placeholder-shaped string stays literal.
+        self.assertEqual(render_template("{{a}}", {"a": "{{ b }}"}), "{{ b }}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`{{ name }}` and `{{name}}` are now the same placeholder.

The strict pattern silently did not match a spaced placeholder, so a template one whitespace away from correct rendered **its own literal text** as the artifact — bytes present, no error, verified clean, wrong. A live authoring loop failed to converge on that character-class difference across four passes; a human squints at it too. Postel's law, scoped strictly to whitespace.

Unknown spaced placeholders raise exactly like tight ones; substituted values are still never re-scanned (covered by tests).

Control: the new tests fail on the old renderer. Suite: **85 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)