### PR TITLE
fix DIRECTORYTOMARKDOWN docstring: documented param name was wrong (directory_path -> directory)

### DIFF
--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -291,12 +291,12 @@ def gemini_prompt_from_file(rdg_file:str, use_filesystem_cache=True, **kwargs) -
 
 def create_markdown_from_directory(rdg_file: str, **kwargs) -> str:
     """
-    Recursively gathers files from a directory, creates a markdown file with file paths
-    and contents in code blocks.
+    Recursively gathers files from a directory as dest=DIRECTORYTOMARKDOWN(directory=path/to/dir),
+    creating a markdown file with file paths and contents in code blocks.
 
     Args:
         rdg_file (str): The path to the rdg file (used for relative path resolution).
-        directory_path (str): The path to the directory to process.
+        directory (str): The path to the directory to process.
     """
     if "directory" not in kwargs:
         raise RdgParserError("The parameter 'directory' is required in DIRECTORYTOMARKDOWN")

--- a/tests/test_docstring_param_truth.py
+++ b/tests/test_docstring_param_truth.py
@@ -1,0 +1,41 @@
+"""A formula's docstring is its published interface: downstream doc surfaces render docstrings,
+and authors (human or LLM) copy parameter names from them. A docstring naming a parameter the
+function does not accept sends every author into a runtime error the docs told them was correct
+(observed live: DIRECTORYTOMARKDOWN documented `directory_path` while raising "The parameter
+'directory' is required" — one downstream agent pass burned per consumer).
+
+This test closes the class, not the instance: for every registered formula whose source raises
+"The parameter 'X' is required", the docstring must mention X.
+"""
+
+import inspect
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.rdg.functions import FUNCTION_REGISTRY
+
+REQUIRED_RE = re.compile(r"[Tt]he (?:parameter )?'?(\w+)'? (?:parameter )?is required")
+
+
+def test_every_required_param_appears_in_its_docstring():
+    failures = []
+    for name, func in FUNCTION_REGISTRY.items():
+        try:
+            source = inspect.getsource(func)
+        except (OSError, TypeError):
+            continue
+        doc = inspect.getdoc(func) or ""
+        for match in REQUIRED_RE.finditer(source):
+            param = match.group(1)
+            if not re.search(rf"\b{re.escape(param)}\b", doc):
+                failures.append(f"{name}: raises for required param '{param}' but its docstring never mentions it")
+    assert failures == [], "\n".join(failures)
+
+
+def test_directorytomarkdown_docstring_names_the_real_param():
+    # The observed instance, pinned directly: the docs said directory_path, the code wants directory.
+    doc = inspect.getdoc(FUNCTION_REGISTRY["DIRECTORYTOMARKDOWN"]) or ""
+    assert "directory (str)" in doc
+    assert "directory_path" not in doc


### PR DESCRIPTION
## What

- `create_markdown_from_directory`'s docstring documented **`directory_path`** while the code requires **`directory`** (raises `The parameter 'directory' is required in DIRECTORYTOMARKDOWN`). Fixed the docstring, and put the copyable idiom `dest=DIRECTORYTOMARKDOWN(directory=path/to/dir)` in the first paragraph so first-paragraph doc renderers carry it.
- New `tests/test_docstring_param_truth.py`: for every registered formula whose source raises "The parameter 'X' is required", the docstring must mention X — plus a pinned assertion that DIRECTORYTOMARKDOWN names `directory` and never `directory_path`.

## Why

A docstring is the formula's published interface: doc surfaces render it verbatim and authors copy parameter names out of it. This one sent every author into the exact runtime error the docs told them was correct. Observed live downstream: an agent wrote `directory_path=` faithfully from the rendered docs, burned a full pass on the `## ERROR`, and then diagnosed the discrepancy itself from the error bytes.

The generic test alone would have passed the old docstring (its prose mentions "a directory"), which is why the instance is also pinned directly.

## Verification

Full suite: **87 passed, 1 skipped** (85 prior + these 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)