### PR TITLE
RDG_EVENTS=jsonl: structured step events on stderr (progress live, origin historical)

### DIFF
--- a/src/rdg/events.py
+++ b/src/rdg/events.py
@@ -1,0 +1,57 @@
+"""Structured step events — the conventional task-queue answer to "how far has this run got?"
+
+Opt-in and additive: with RDG_EVENTS=jsonl set, the engine emits one JSON object per line on
+STDERR at each step boundary (stdout stays untouched — it may carry content). Without the env
+var, nothing is emitted and nothing else changes. The shape follows ninja/cargo-style progress
+and Celery-style state: a live reader gets progress; a persisted stream gets history — including
+which files each step wrote, so artifact origin is the historical read of the same events.
+
+Human-readable lines ride the stock ``logging`` module (logger ``rdg``): events are mirrored at
+DEBUG, and RDG_LOG_FILE attaches a FileHandler so a run can keep a plain log beside the machine
+stream. Neither env var set → both features dormant.
+
+Event shape (all step events):
+    {"ev": "step_start", "i": 3, "n": 9, "dest": "out/x.md", "formula": "CREATEFILE", "ts": "..."}
+    {"ev": "step_end",   "i": 3, "n": 9, "dest": "out/x.md", "formula": "CREATEFILE",
+     "ok": true, "wrote": ["out/x.md"], "ts": "..."}
+
+``wrote`` lists the paths the step actually wrote — on failure that is still the destination
+(the engine writes ## ERROR bytes there), with ``ok`` false so a consumer distinguishes created
+content from recorded failure.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+_logger = logging.getLogger("rdg")
+_log_file_attached = False
+
+
+def _ensure_log_file() -> None:
+    global _log_file_attached
+    if _log_file_attached:
+        return
+    log_path = os.environ.get("RDG_LOG_FILE")
+    if log_path:
+        handler = logging.FileHandler(log_path)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        _logger.addHandler(handler)
+        _logger.setLevel(logging.DEBUG)
+    _log_file_attached = True
+
+
+def events_enabled() -> bool:
+    return os.environ.get("RDG_EVENTS") == "jsonl"
+
+
+def emit(ev: str, **fields) -> None:
+    """Emit one event. No-op unless RDG_EVENTS=jsonl; mirrored to the ``rdg`` logger at DEBUG."""
+    _ensure_log_file()
+    payload = {"ev": ev, **fields, "ts": datetime.now(timezone.utc).isoformat()}
+    line = json.dumps(payload, separators=(",", ":"))
+    _logger.debug("event %s", line)
+    if events_enabled():
+        print(line, file=sys.stderr, flush=True)

--- a/src/rdg/parser.py
+++ b/src/rdg/parser.py
@@ -4,6 +4,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from .functions import FUNCTION_REGISTRY, RdgParserError, _READ_FENCE
+from .events import emit
 
 def parse_rdg_line(line: str, file_dir: str = ".") -> tuple[str, str, dict[str, Any]]:
     """Parses a single line of the rdg file."""
@@ -51,7 +52,7 @@ def parse_rdg_line(line: str, file_dir: str = ".") -> tuple[str, str, dict[str, 
     return output_file, formula_name, arguments
 
 
-def _run_step(rdg_file: str, file_dir: str, line: str, fence=None) -> int:
+def _run_step(rdg_file: str, file_dir: str, line: str, fence=None, progress=None) -> int:
     """Execute one line of an rdg file. Returns 1 if the step failed, else 0.
 
     This is the serial loop body, extracted verbatim so the serial path and the RDG_JOBS wave
@@ -63,12 +64,19 @@ def _run_step(rdg_file: str, file_dir: str, line: str, fence=None) -> int:
     step_label). It arms the read-fence in process_input for the duration of the formula call.
     ContextVars are per-thread, and this runs inside the worker thread, so arming it here
     scopes it to exactly this step.
+
+    `progress` is (index, total), 1-based, when the caller knows it. Both runners pass it; step
+    events (events.py, RDG_EVENTS=jsonl) carry it so a live reader can render [i/n]. Emission
+    lives HERE so the two runners cannot drift on observability either.
     """
     output_path = None
+    formula_name = None
+    i, n = progress if progress is not None else (None, None)
     try:
         output_file, formula_name, arguments = parse_rdg_line(line, file_dir)
         if not output_file:  # skip empty lines or comments
             return 0
+        emit("step_start", i=i, n=n, dest=output_file, formula=formula_name)
 
         # Resolved before the formula is looked up, so the error handlers always have a
         # path to write to. An unknown formula used to raise KeyError here, and the
@@ -96,19 +104,36 @@ def _run_step(rdg_file: str, file_dir: str, line: str, fence=None) -> int:
 
         with open(output_path, 'w') as outfile:
             outfile.write(result)
+        emit("step_end", i=i, n=n, dest=output_file, formula=formula_name, ok=True, wrote=[output_file])
         return 0
     except KeyError as e:
         print(f"Unknown formula on line '{line.strip()}': {e}", file=sys.stderr)
         _write_error(output_path, f"Unknown formula: {e}")
+        emit("step_end", i=i, n=n, dest=_dest_or_none(output_path, file_dir), formula=formula_name, ok=False, wrote=_wrote(output_path, file_dir))
         return 1
     except RdgParserError as e:
         print(f"Error processing line '{line.strip()}': {e}", file=sys.stderr)
         _write_error(output_path, e)
+        emit("step_end", i=i, n=n, dest=_dest_or_none(output_path, file_dir), formula=formula_name, ok=False, wrote=_wrote(output_path, file_dir))
         return 1
     except Exception as e:
         print(f"An unexpected error occurred processing line '{line.strip()}': {e}", file=sys.stderr)
         _write_error(output_path, e)
+        emit("step_end", i=i, n=n, dest=_dest_or_none(output_path, file_dir), formula=formula_name, ok=False, wrote=_wrote(output_path, file_dir))
         return 1
+
+
+def _dest_or_none(output_path, file_dir):
+    """The step's dest relative to its file_dir, or None when the line never parsed far enough."""
+    if output_path is None:
+        return None
+    return os.path.relpath(output_path, file_dir)
+
+
+def _wrote(output_path, file_dir):
+    """What a FAILED step actually wrote: its destination (## ERROR bytes) when one was resolved."""
+    dest = _dest_or_none(output_path, file_dir)
+    return [dest] if dest is not None else []
 
 
 def process_rdg_file(rdg_file: str, file_dir: str = ".") -> int:
@@ -116,11 +141,21 @@ def process_rdg_file(rdg_file: str, file_dir: str = ".") -> int:
     failures = 0
     try:
         with open(rdg_file, 'r') as f:
-            for line in f:
-                # Parsing happens INSIDE the per-line try (in _run_step). Outside it, a single
-                # malformed line or unknown formula raised past the loop to the file-level handler
-                # below, which silently abandoned every remaining line — and the CLI still
-                # reported success.
+            lines = f.readlines()
+        # Steps are counted up front so progress events can say [i/n]; comments and blanks are
+        # excluded from n the same way _run_step skips them, so n matches what actually runs.
+        real = [ln for ln in lines if ln.strip() and not ln.strip().startswith('#')]
+        total = len(real)
+        step_no = 0
+        for line in lines:
+            # Parsing happens INSIDE the per-line try (in _run_step). Outside it, a single
+            # malformed line or unknown formula raised past the loop to the file-level handler
+            # below, which silently abandoned every remaining line — and the CLI still
+            # reported success.
+            if line.strip() and not line.strip().startswith('#'):
+                step_no += 1
+                failures += _run_step(rdg_file, file_dir, line, progress=(step_no, total))
+            else:
                 failures += _run_step(rdg_file, file_dir, line)
     except FileNotFoundError:
         print(f"Error: RDF file not found at '{rdg_file}'", file=sys.stderr)
@@ -320,7 +355,7 @@ def process_rdg_file_parallel(rdg_file: str, file_dir: str = ".", jobs: int = 2)
                 s = steps[i]
                 allowed = {steps[a]["norm"] for a in ancestors[i]} | {s["norm"]}
                 fence = (all_dests, allowed, f"step {i + 1} ({s['dest']})")
-                futures.append(pool.submit(_run_step, rdg_file, file_dir, s["line"], fence))
+                futures.append(pool.submit(_run_step, rdg_file, file_dir, s["line"], fence, (i + 1, len(steps))))
             for fut in futures:
                 failures += fut.result()
     return failures

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,109 @@
+"""RDG_EVENTS=jsonl — structured step events on stderr, opt-in, both runners.
+
+Contract under test:
+  - env absent: zero event lines (the feature is invisible — nothing else changes).
+  - RDG_EVENTS=jsonl: one step_start + one step_end per real step on STDERR, each line valid
+    JSON, with 1-based i/n progress, dest, formula; stdout untouched.
+  - a failing step emits step_end ok=false with the destination in wrote (## ERROR bytes are
+    still a write); a consumer can distinguish created content from recorded failure.
+  - RDG_JOBS wave runner emits the same events (shared _run_step emission).
+Hermetic: deterministic formulas only.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run(tmp, rdg_body, env_extra=None):
+    for name in ("in1.txt", "in2.txt"):
+        with open(os.path.join(tmp, name), "w") as handle:
+            handle.write(name)
+    rdg = os.path.join(tmp, "t.rdg")
+    with open(rdg, "w") as handle:
+        handle.write(rdg_body)
+    env = dict(os.environ)
+    inherited = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = REPO + (os.pathsep + inherited if inherited else "")
+    env.pop("RDG_EVENTS", None)
+    env.pop("RDG_LOG_FILE", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, "-m", "src.rdg.rdg_cli", rdg],
+        capture_output=True, text=True, env=env, cwd=tmp,
+    )
+
+
+def _events(stderr):
+    out = []
+    for line in stderr.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "ev" in obj:
+                out.append(obj)
+    return out
+
+
+BODY = "out/a.md=UPPERCASE(file=in1.txt)\n# comment\nout/b.md=UPPERCASE(file=in2.txt)\n"
+
+
+class EventsOptIn(unittest.TestCase):
+    def test_absent_env_emits_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = _run(tmp, BODY)
+            self.assertEqual(_events(r.stderr), [])
+
+    def test_jsonl_emits_start_end_per_step_with_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = _run(tmp, BODY, {"RDG_EVENTS": "jsonl"})
+            evs = _events(r.stderr)
+            starts = [e for e in evs if e["ev"] == "step_start"]
+            ends = [e for e in evs if e["ev"] == "step_end"]
+            self.assertEqual(len(starts), 2)
+            self.assertEqual(len(ends), 2)
+            self.assertEqual([e["i"] for e in starts], [1, 2])
+            self.assertTrue(all(e["n"] == 2 for e in starts))
+            self.assertEqual(starts[0]["dest"], "out/a.md")
+            self.assertEqual(starts[0]["formula"], "UPPERCASE")
+            self.assertTrue(all(e["ok"] for e in ends))
+            self.assertEqual(ends[0]["wrote"], ["out/a.md"])
+
+    def test_failing_step_emits_ok_false_with_wrote(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = _run(tmp, "out/bad.md=UPPERCASE(nope=1)\n", {"RDG_EVENTS": "jsonl"})
+            ends = [e for e in _events(r.stderr) if e["ev"] == "step_end"]
+            self.assertEqual(len(ends), 1)
+            self.assertFalse(ends[0]["ok"])
+            self.assertEqual(ends[0]["wrote"], ["out/bad.md"])
+
+    def test_wave_runner_emits_same_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = _run(tmp, BODY, {"RDG_EVENTS": "jsonl", "RDG_JOBS": "2"})
+            evs = _events(r.stderr)
+            self.assertEqual(len([e for e in evs if e["ev"] == "step_start"]), 2)
+            ends = [e for e in evs if e["ev"] == "step_end"]
+            self.assertEqual(len(ends), 2)
+            self.assertTrue(all(e["n"] == 2 for e in ends))
+
+    def test_log_file_records_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "run.log")
+            _run(tmp, BODY, {"RDG_LOG_FILE": log})
+            with open(log) as handle:
+                content = handle.read()
+            self.assertIn("step_start", content)
+            self.assertIn("out/a.md", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Opt-in structured step events, the conventional task-queue shape (ninja/cargo-style progress, Celery-style state):

- `RDG_EVENTS=jsonl` → one JSON object per line on **stderr** at each step boundary:
  `step_start {"i", "n", "dest", "formula", "ts"}` and `step_end {…, "ok", "wrote"}`. stdout untouched; env absent → zero change.
- Progress is 1-based `[i/n]`, comments/blanks excluded from `n`. Both runners (serial and RDG_JOBS waves) emit identically — emission lives inside the shared `_run_step`, so observability can't drift between them any more than semantics can.
- A failed step emits `ok: false` with its destination in `wrote` — `## ERROR` bytes are a write; consumers distinguish created content from recorded failure. **Origin is the historical read of the same stream** (which step wrote which file); progress is the live read.
- Stock `logging` underneath (logger `rdg`): events mirror at DEBUG; `RDG_LOG_FILE` attaches a FileHandler for a plain per-run log.

## Why

Downstream, a console showing runs can only say queued/running/done — its own spec rules out inferring progress from outside ("improve the rdg interface so the engine reports it"), and nothing distinguishes what created a file. One engine feature answers both, with no new subsystem and zero behavior change for plain users.

## Verification

`tests/test_events.py` (5 tests): absent-env emits nothing (control); start+end per step with correct `i/n/dest/formula`; failing-step shape; wave-runner parity; log-file capture. Full suite: **92 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)