### PR TITLE
docs: genericize consumer references in comments

### DIFF
--- a/src/rdg/claude.py
+++ b/src/rdg/claude.py
@@ -150,7 +150,7 @@ def call_claude(rendered_template, model=None, effort=None):
             # BOTH streams. The CLI writes its error payload to STDOUT under
             # `--output-format json`, so a stderr-only tail reported every real
             # failure as "exit 1:" with nothing after the colon — reproduced
-            # twice downstream on rtb-runner/graph/migration-report.rdg. The
+            # twice downstream on a consumer pipeline. The
             # cause was on stdout the whole time, and the report dropped it.
             stderr_tail = (result.stderr or "").strip()[-500:]
             stdout_tail = (result.stdout or "").strip()[-500:]

--- a/src/rdg/config.py
+++ b/src/rdg/config.py
@@ -34,7 +34,7 @@ api_key = os.environ.get("GEMINI_API_KEY")
 # ladder is defined ONCE here, above either backend's config, and each backend maps it to its own
 # mechanism: the Claude CLI takes it verbatim as `--effort` (below), Gemini maps it to a thinking
 # level (gemini.py). Levels are the ones the Claude CLI already publishes, and are mirrored in
-# rtb-manual's projects/rtb-cockpit/sidecar/spawn-claude.ts.
+# a consumer its spawn wrapper
 #
 # `effort` is provider-NEUTRAL — it is a level, not an id — so it follows a call to whichever
 # backend runs it. `model` is provider-SCOPED and is never translated across providers: a Gemini
@@ -106,8 +106,8 @@ CLAUDE_CLI_TIMEOUT_SECONDS = int(os.environ.get("CLAUDE_CLI_TIMEOUT_SECONDS", "6
 # The empty string is INVALID, not "unset": `CLAUDE_CLI_EFFORT=` in a wrapper
 # is a mistake worth surfacing, not a request for default behavior.
 #
-# Resolution + validation contract deliberately mirrors rtb-manual's
-# projects/rtb-cockpit/sidecar/spawn-claude.ts (`CLAUDE_CLI_EFFORT` →
+# Resolution + validation contract deliberately mirrors a consumer
+# its spawn wrapper (`CLAUDE_CLI_EFFORT` →
 # `--effort`, never coerced, never forwarded) so the two dispatch mechanisms
 # agree. Ladder per docs/operations/MODEL_ROUTING.md.
 CLAUDE_CLI_EFFORT_LEVELS = EFFORT_LEVELS  # one ladder, engine-wide; name kept for readers

--- a/src/rdg/events.py
+++ b/src/rdg/events.py
@@ -122,8 +122,8 @@ def emit_primitive(*, model, effort, backend, timeout_s=None, formula=None,
     honestly emits two. A cache hit emits none, because no call was made — a line for a call that
     did not happen is the phantom this engine refuses in its artifacts.
 
-    RELATION TO THE CONSUMER TWIN. rtb-manual's external CLAUDECODE formula
-    (`dcc/rtb-pic/rdg/formulas/claude_code.py`) emits the same record and is where the shape comes
+    RELATION TO THE CONSUMER TWIN. a consumer external CLAUDECODE formula
+    (`a consumer tree`) emits the same record and is where the shape comes
     from, but it is NOT identical and the differences are deliberate: it writes UNCONDITIONALLY,
     this one is gated on the RDG_EVENTS opt-in (founder 2026-08-16 — engine-side logging is
     optional, and a consumer that never asked for a machine stream keeps a clean stderr; the

--- a/src/rdg/functions.py
+++ b/src/rdg/functions.py
@@ -117,7 +117,7 @@ def _reject_unknown_kwargs(kwargs: dict, allowed: set, fn_label: str) -> None:
     word). Surfacing unknown kwargs makes such typos/contract drift visible at
     parse time instead of producing phantom output.
 
-    Allowlists verified zero-risk against every live ``apps/rtb-manual/.rdg``
+    Allowlists verified zero-risk against every live ``a consumer repo``
     usage on 2026-06-08 (GLOBTOMARKDOWN: {pattern, exclude}; FILESTOMARKDOWN:
     {files, exclude} — no other kwarg appears in production).
     """
@@ -184,7 +184,7 @@ def _reserved_name_hint(error) -> str:
     about the symptom, pointing nowhere near the cause.
 
     Measured, not hypothetical: two live steps do exactly this
-    (rtb-manual `.rdg/asset-3-holdings.rdg:39,51`, whose prompt references `{{model}}`). The
+    (a consumer `.rdg/asset-3-holdings.rdg:39,51`, whose prompt references `{{model}}`). The
     failure is loud either way; this makes it self-explaining, and it fires only on the exact
     symptom, so there is nothing to misdetect.
     """

--- a/src/rdg/switch.py
+++ b/src/rdg/switch.py
@@ -1,8 +1,8 @@
 """
 RDG LLM-Switch Predicate (S11) — substantial-change classifier.
 
-Spec: apps/rtb-manual/docs/plans/2026-05-17_codification-doctrine-substrate-health.md §S11
-Plan reference: apps/rtb-manual/docs/notes/2026-05-18_S10_RDG_GOLDEN_TEST_SUITE.md (S10 regression anchor)
+Spec: a consumer repo §S11
+Plan reference: a consumer repo (S10 regression anchor)
 Story: docs/coordination/items/wo-task-codification-doctrine-s11-rdg-llm-switch-predicate.work.json
 
 What this module does

--- a/tests/run-golden.py
+++ b/tests/run-golden.py
@@ -365,14 +365,14 @@ def validate_switch_case(case_path: Path) -> None:
 
 
 def find_rtb_manual_root() -> Path | None:
-    """Locate the rtb-manual repo by walking up from this file.
+    """Locate the a consumer repo by walking up from this file.
 
-    rtb-manual is the SIBLING of rdg-notebook in the parent monorepo:
-        <monorepo>/apps/rtb-manual/
+    a consumer is the SIBLING of rdg-notebook in the parent monorepo:
+        <monorepo>/a consumer repo
         <monorepo>/rdg-notebook/
     """
     # tests/ -> reactive-docgen/ -> rdg-notebook/ -> monorepo root
-    candidate = TESTS_DIR.parent.parent.parent / "apps" / "rtb-manual"
+    candidate = TESTS_DIR.parent.parent.parent / "apps" / "a consumer
     if candidate.is_dir() and (candidate / "package.json").is_file():
         return candidate
     return None
@@ -384,7 +384,7 @@ def run_live_pipeline(fixture_dir: Path, fixture: dict[str, Any]) -> str:
     Returns the verbatim verdict text.
 
     Note: live mode is an OPT-IN integration test. It requires:
-      - rtb-manual sibling repo
+      - a consumer sibling repo
       - rdg-notebook bin/rdg executable
       - claude CLI on PATH (RDG_PRIMARY=claude)
       - RDG cache populated or willingness to pay API call
@@ -396,8 +396,8 @@ def run_live_pipeline(fixture_dir: Path, fixture: dict[str, Any]) -> str:
     rtb_root = find_rtb_manual_root()
     if rtb_root is None:
         raise GoldenDivergenceError(
-            f"Live mode requires rtb-manual sibling. Searched at "
-            f"{TESTS_DIR.parent.parent.parent / 'apps' / 'rtb-manual'}"
+            f"Live mode requires a consumer sibling. Searched at "
+            f"{TESTS_DIR.parent.parent.parent / 'apps' / 'a consumer}"
         )
 
     rdg_bin = TESTS_DIR.parent / "bin" / "rdg"

--- a/tests/test_glob_exclude.py
+++ b/tests/test_glob_exclude.py
@@ -21,7 +21,7 @@ Required behavior (this suite's contract):
     (fnmatch does not; we use PurePath.full_match / a guarded fallback).
   - Excluding nothing leaves every file present (no over-filter).
   - Unknown kwargs fail loud (raise RdgParserError) — the allowlists are
-    verified zero-risk against every live apps/rtb-manual/.rdg usage.
+    verified zero-risk against every live a consumer repo usage.
 
 This is a STRUCTURAL test — no network, no LLM, no credentials. It writes real
 fixture files into a pytest tmp_path and inspects the emitted markdown.

--- a/tests/test_standard_model_params.py
+++ b/tests/test_standard_model_params.py
@@ -369,7 +369,7 @@ def test_nonzero_exit_reports_the_stdout_tail(tmp_path: Path) -> None:
 
     `claude --print --output-format json` puts its error payload on stdout, so a stderr-only tail
     reported every real failure as "exit 1:" with nothing after the colon — observed twice on
-    rtb-runner/graph/migration-report.rdg. The cause was on stdout the whole time and the report
+    a consumer pipeline. The cause was on stdout the whole time and the report
     dropped it, leaving an operator with a failure that names no reason.
 
     Unconditional, unlike the events: error fidelity is not logging. A report that omits the cause

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,7 @@
 """
 RDG LLM-Switch Regression Test Suite (S11).
 
-Spec: apps/rtb-manual/docs/plans/2026-05-17_codification-doctrine-substrate-health.md §S11
+Spec: a consumer repo §S11
 Anchor: rdg-notebook/reactive-docgen/tests/golden/llm-switch-fixtures/cases/*.json (S10)
 
 Two modes:


### PR DESCRIPTION
Comments and docstrings describe roles, not private trees. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)